### PR TITLE
Fixed a crash when calling ":split".

### DIFF
--- a/draw.c
+++ b/draw.c
@@ -1114,7 +1114,7 @@ static void updateimage(win)
 			logicaltab = 0;
 		else
 		{
-			for (i = 0; di->newline[i].startrow < row && di->newline[i + 1].startrow - 1 < row; i++)
+			for (i = 0; di->newline[i].startrow < row && di->nlines > i && di->newline[i + 1].startrow - 1 < row; i++)
 			{
 			}
 			logicaltab = (row - di->newline[i].startrow) * ncols;


### PR DESCRIPTION
Maybe I'm wrong and this isn't the right way to fix this crash, so please review this changeset.

```
 Program received signal SIGSEGV, Segmentation fault.
 0x0000000000437ec8 in updateimage (win=0x6c9220) at draw.c:1117
 1117                            for (i = 0; di->newline[i].startrow < row && di->newline[i + 1].startrow - 1 < row; i++)
 (gdb) print i
 $1 = 1371
 (gdb) print di->newline[1372]
 Cannot access memory at address 0x6e8000
```
