### PR TITLE
configure: fixed X11 libraries detection on RedHat/CentOS

### DIFF
--- a/configure
+++ b/configure
@@ -431,7 +431,8 @@ fi
 # If X-windows is used, then check for the -lXpm library, need for FEATURE_IMAGE
 if [ "$GUI_X11" = "define" -a "$FEATURE_IMAGE" = "" ]
 then
-	if [ "`searchpath libXpm.a $XLIBPATH`" = "" ]
+	if [ "`searchpath libXpm.a $XLIBPATH`" = "" ] \
+		&& [ "`searchpath libXpm.so $XLIBPATH`" = "" ]
 	then
 		why "   Disabling the use of background images since -lXpm wasn't found"
 		FEATURE_IMAGE=undef
@@ -460,6 +461,7 @@ case "$FEATURE_XFT" in
 	then
 		xft_h=`searchpath X11/Xft/Xft.h $XINCPATH`
 		libxft=`searchpath libXft.a $XLIBPATH`
+		[ -n "$libxft" ] || libxft=`searchpath libXft.so $XLIBPATH`
 		if [ "$xft_h" = "" -o "$libxft" = "" ]
 		then
 			why "   Xft not found"


### PR DESCRIPTION
With this fix, elvis can be built from source on rhel-6.5 (and centos-6.5) on x86_64.
I've configured it like this:

``` sh
$ ./configure --verbose --with-x --x-libraries=/usr/lib64 --prefix=/usr/local/opt/elvis-2.2-git
```

And it has now successfully detected `Xpm` and `Xft`:

```
   [...]
   X11 headers found
   X11 libraries found
   GCC found
   Enabling the use of background images since -lXpm and <X11/xpm.h> were found
   Xft found -- elvis will use it
   [...]
```
