### PR TITLE
fixed: Makefile.in: specifying a nonexisting directory to '--prefix' (in 'configure') now works

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -423,7 +423,7 @@ install: install.$(OS)
 
 install.unix: $(ALL) doc/elvtags.man
 	rm -f doc/*.bak
-	[ -d $(BINDIR) ] || mkdir $(BINDIR)
+	[ -d $(BINDIR) ] || mkdir -p $(BINDIR)
 	cp $(ALL) $(BINDIR)
 	(cd $(BINDIR); chmod 0755 $(ALL))
 	rm -rf $(DATADIR)


### PR DESCRIPTION
When running `configure` with a `--prefix` equal to a non-existing directory, the `make install` fails. This simple fix makes sure that the (parent) directories leading to the `--prefix` are created at _install_ time.
