### PR TITLE
window ordering more natural in termcap (splits too)

### DIFF
--- a/dmsyntax.c
+++ b/dmsyntax.c
@@ -1504,7 +1504,7 @@ static MARK image(w, line, info, draw)
 			{
 				sinfo->token = PREPWORD;
 			}
-			else if (sinfo->token == PREPWORD && !elvalnum(*cp))
+			else if (sinfo->token == PREPWORD && !elvalnum(*cp) && *cp != '_')
 			{
 				sinfo->token = PUNCT;
 				expectprepq = ElvTrue;

--- a/guitcap.c
+++ b/guitcap.c
@@ -1813,7 +1813,6 @@ static ELVBOOL creategw(name, firstcmd)
 	char	*firstcmd;	/* first command to run in window */
 {
 	TWIN	*newp;
-	TWIN	*twinstmp;
 #ifdef FEATURE_MISC
 	BUFFER	buf;
 #endif
@@ -1842,17 +1841,8 @@ static ELVBOOL creategw(name, firstcmd)
 	newp->shape = CURSOR_NONE;
 
 	/* insert the new window into the list of windows */
-	if (current) {
-		/* ...after the current window */
-		twinstmp = twins;
-	 	while(twinstmp != NULL && twinstmp != current)
-	 		twinstmp = twinstmp->next;
-		newp->next = twinstmp->next;
-		twinstmp->next= newp;
-	} else {
-		newp->next = twins;
-		twins = newp;
-	}
+	newp->next = twins;
+	twins = newp;
 	nwindows++;
 
 	/* adjust the heights of the other windows to make room for this one */

--- a/guitcap.c
+++ b/guitcap.c
@@ -1813,6 +1813,7 @@ static ELVBOOL creategw(name, firstcmd)
 	char	*firstcmd;	/* first command to run in window */
 {
 	TWIN	*newp;
+	TWIN	*twinstmp;
 #ifdef FEATURE_MISC
 	BUFFER	buf;
 #endif
@@ -1841,8 +1842,17 @@ static ELVBOOL creategw(name, firstcmd)
 	newp->shape = CURSOR_NONE;
 
 	/* insert the new window into the list of windows */
-	newp->next = twins;
-	twins = newp;
+	if (current) {
+		/* ...after the current window */
+		twinstmp = twins;
+	 	while(twinstmp != NULL && twinstmp != current)
+	 		twinstmp = twinstmp->next;
+		newp->next = twinstmp->next;
+		twinstmp->next= newp;
+	} else {
+		newp->next = twins;
+		twins = newp;
+	}
 	nwindows++;
 
 	/* adjust the heights of the other windows to make room for this one */

--- a/main.c
+++ b/main.c
@@ -920,6 +920,7 @@ int main(argc, argv)
 	char	**argv;	/* values of the command-line arguments */
 {
 	init(argc, argv);
+	exstring(windefault, toCHAR("window 1"), NULL);
 	(*gui->loop)();
 	term();
 #if !defined (GUI_WIN32)

--- a/move.c
+++ b/move.c
@@ -609,6 +609,7 @@ RESULT m_mark(win, vinf)
 
 	/* move to the named mark */
 	marksetoffset(win->state->cursor, markoffset(newmark));
+	msg(MSG_INFO, "[C]on mark $1", vinf->key2);
 	return RESULT_COMPLETE;
 }
 

--- a/version.h
+++ b/version.h
@@ -6,7 +6,7 @@
  *	README.html, search for the actual version number
  */
 
-#define VERSION	"2.2.1-prerelease"
+#define VERSION	"2.2.1-prerelease ($Revision$)"
 #define COPY1 "Copyright (c) 1995-2003 by Steve Kirkendall"
 #if 1
 # define COPY2 "Permission is granted to redistribute the source or binaries under the terms of"

--- a/vicmd.c
+++ b/vicmd.c
@@ -276,7 +276,7 @@ RESULT v_setmark(win, vinf)
 
 	/* set the mark */
 	namedmark[vinf->key2 - 'a'] = markdup(win->state->cursor);
-	msg(MSG_INFO, "[c]set mark $1", vinf->key2);
+	msg(MSG_INFO, "[C]set mark $1", vinf->key2);
 	return RESULT_COMPLETE;
 }
 

--- a/vicmd.c
+++ b/vicmd.c
@@ -515,7 +515,7 @@ RESULT v_window(win, vinf)
 		}
 		break;
 
-	  case 'k':
+	  case 'j':
 		/* move up 1 window */
 		for (next = NULL; winofbuf(next, NULL) != win; )
 		{
@@ -525,7 +525,7 @@ RESULT v_window(win, vinf)
 		}
 		break;
 
-	  case 'j':
+	  case 'k':
 		/* move down 1 window */
 		next = winofbuf(win, NULL);
 		break;

--- a/vicmd.c
+++ b/vicmd.c
@@ -515,7 +515,7 @@ RESULT v_window(win, vinf)
 		}
 		break;
 
-	  case 'j':
+	  case 'k':
 		/* move up 1 window */
 		for (next = NULL; winofbuf(next, NULL) != win; )
 		{
@@ -525,7 +525,7 @@ RESULT v_window(win, vinf)
 		}
 		break;
 
-	  case 'k':
+	  case 'j':
 		/* move down 1 window */
 		next = winofbuf(win, NULL);
 		break;

--- a/vicmd.c
+++ b/vicmd.c
@@ -276,6 +276,7 @@ RESULT v_setmark(win, vinf)
 
 	/* set the mark */
 	namedmark[vinf->key2 - 'a'] = markdup(win->state->cursor);
+	msg(MSG_INFO, "[c]set mark $1", vinf->key2);
 	return RESULT_COMPLETE;
 }
 


### PR DESCRIPTION
* > elvis a b c d -a

  before:
  shows the windows in reverse order (d on top, a on the bottom)

  now:
  a is on top, d on the bottom

* split was putting the new window on the top. Which is fine but
  if you work with several buffers and split windows this mode
  is the least obvious to keep things together.

  before: windows a -> b -> c -> d
          current c
          split results in  new-c -> b -> c -> d

  now     split results in a -> b -> c -> new-c -> d