### PR TITLE
Fixed warning that wait was implicitly declared

### DIFF
--- a/osunix/osprg.c
+++ b/osunix/osprg.c
@@ -6,14 +6,12 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <string.h>
+#include <sys/wait.h>
 #include "elvis.h"
+
 #ifdef FEATURE_RCSID
 char id_osprg[] = "$Id: osprg.c,v 2.13 2003/10/17 17:41:23 steve Exp $";
 #endif
-#ifdef NEED_WAIT_H
-# include <sys/wait.h>
-#endif
-
 
 #define TMPDIR	(o_directory ? tochar8(o_directory) : "/tmp")
 #define SHELL	(o_shell ? tochar8(o_shell) : "/bin/sh")


### PR DESCRIPTION
This define was never in the makefile post-configure, all unix-like systems have the standard wait() nowadays, so lets just use it.

**sys/wait.h** can be used by GNU/Linux, BSD, macOS and causes no portability issues.