### PR TITLE
Allow negative values for aasqueeze

### DIFF
--- a/README.html
+++ b/README.html
@@ -228,8 +228,8 @@ Toggles text between uppercase and lowercase.
 <dd>For "x11" only, the <strong>antialias</strong> option controls whether
 Elvis will use the Xft library to draw antialiased text.
 Antialiased fonts tend to leave a much larger gap between lines, so the
-<strong>aasqueeze</strong> option gives you a way to reduce that gap, and
-get more lines on the screen.
+<strong>aasqueeze</strong> option gives you a way to reduce/increase that
+gap, and get more/less lines on the screen.
 
 <dt>auevent, aufilename, and auforce
 <dd>These options are only defined during an autocmd event.

--- a/doc/elvisopt.html
+++ b/doc/elvisopt.html
@@ -1767,7 +1767,12 @@ Since programmers like to see as many lines of their code as possible,
 I decided to create this option for trimming down gap.
 The default value is 4, which reduces the height of each text row by
 4 raster lines.
-You can set it to any value from 0 to 10.
+A negative value will add extra whitespace between the lines, which may serve
+two purposes: if a font has descenders that don't show for aasqueeze=0, like
+the '_' character, setting aasqueeze to -2 might make it visible. The other
+purpose might be simulating double line-height in presentations by choosing
+a high negative value like aasqueeze=-10
+You can set it to any value from -10 to 10.
 
 <dt><a name="scrollbarleft">scrollbarleft, xsl <em>(Boolean, x11)</em></a>
 <dd>The <em>scrollbarleft</em> option determines which side of the window the

--- a/guix11/guix11.c
+++ b/guix11/guix11.c
@@ -266,7 +266,7 @@ static OPTDESC x11desc[] =
 	{"secret", "secret",	optnstring,	optisnumber	}
 #ifdef FEATURE_XFT
        ,{"antialias", "aa",	NULL,		NULL		},
-	{"aasqueeze", "aas",	optnstring,	xoptisnumber,	"0:10"}
+	{"aasqueeze", "aas",	optnstring,	xoptisnumber,	"-10:10"}
 #endif
 };
 


### PR DESCRIPTION
A negative value will add extra whitespace between the lines, which may serve
two purposes: if a font has descenders that don't show for aasqueeze=0, like
the '_' character, setting aasqueeze to -2 might make it visible. The other
purpose might be simulating double line-height in presentations by choosing
a high negative value like aasqueeze=-10

Signed-off-by: H.Merijn Brand - Tux <linux@tux.freedom.nl>