### PR TITLE
Avoid redrawing UI after events that don't change the buffer

### DIFF
--- a/guiwin32/guiwin.c
+++ b/guiwin32/guiwin.c
@@ -301,27 +301,6 @@ static void gwloop (void)
 	msg.message = 0;
 	while (gw_def_win.nextp != NULL)
 	{
-		/* NOTE: For some reason, WinElvis receives an incessant stream of
-		 * 0x0118 messages when it should be idle.  I have no idea why, or
-		 * even what 0x0118 means.  I know 0x0117 is WM_ITEMMENUPOPUP and
-		 * 0x011f is WM_MENUSELECT, but 0x0118 isn't defined in <winuser.h>
-		 *
-		 * Those messages are harmless, except that they interfere with the
-		 * blinking of the cursor.  If elvis doesn't update screens after a
-		 * 0x0118 message, then the cursor blinks and everything looks good.
-		 * I wish I know why this is happening, but for now I'm content to
-		 * simply have this work-around.
-		 *
-		 * This behavior is new in 2.2g-beta; it didn't occur in 2.2f-beta.
-		 * I tried restoring the 2.2f versions of the guiwin32/* files, but
-		 * that had no effect.
-		 */
-
-		/* repaint the windows */
-		if (msg.message != WM_PAINT && msg.message != 0x0118)
-			for (gwp = gw_def_win.nextp; gwp != NULL; gwp = gwp->nextp)
-				gw_redraw_win (gwp);
-
 		/* process Windows messages */
 		GetMessage (&msg, NULL, 0, 0);
 		TranslateMessage (&msg);
@@ -429,6 +408,9 @@ static ELVBOOL gwcreategw(char *name, char *firstcmd)
 	/* make window active */
 	eventfocus((GUIWIN *)gwp, ElvTrue);
 	gwp->active = 1;
+
+	/* redraw the contents */
+	gw_redraw_win (gwp);
 
 	/* show the window */
 	ShowWindow (gwp->frameHWnd, SW_SHOW);

--- a/guiwin32/guiwin.c
+++ b/guiwin32/guiwin.c
@@ -226,55 +226,55 @@ static int gwtest (void)
 
 static int gwinit (int argc, char *argv[])
 {
-    register int        i;
-    long		color;
+	register int        i;
+	long		color;
 
-    gw_def_win.nextp = NULL;
+	gw_def_win.nextp = NULL;
 
-    /* map the virtual keys. */
-    for (i = 0; gwkeys[i].label != 0; i++)
-        if (gwkeys[i].cooked)
-            mapinsert ((unsigned char *)gwkeys[i].rawin, 
-                       strlen ((char *)gwkeys[i].rawin),
-                       (unsigned char *)gwkeys[i].cooked, 
-                       strlen ((char *)gwkeys[i].cooked),
-                       (unsigned char *)gwkeys[i].label, 
-                       gwkeys[i].flags, NULL);
+	/* map the virtual keys. */
+	for (i = 0; gwkeys[i].label != 0; i++)
+		if (gwkeys[i].cooked)
+			mapinsert ((unsigned char *)gwkeys[i].rawin, 
+			           strlen ((char *)gwkeys[i].rawin),
+			           (unsigned char *)gwkeys[i].cooked, 
+			           strlen ((char *)gwkeys[i].cooked),
+			           (unsigned char *)gwkeys[i].label, 
+			           gwkeys[i].flags, NULL);
 
-    /* set default values for options */
-    optpreset (o_scrollbar (&gw_def_win), ElvTrue, OPT_REDRAW|OPT_HIDE);
-    optpreset (o_toolbar (&gw_def_win), ElvTrue, OPT_REDRAW|OPT_HIDE);
-    optpreset (o_statusbar (&gw_def_win), ElvTrue, OPT_REDRAW|OPT_HIDE);
-    optpreset (o_menubar (&gw_def_win), ElvTrue, OPT_REDRAW|OPT_HIDE);
-    optpreset (o_font (&gw_def_win), DEFAULT_FONT, OPT_REDRAW|OPT_HIDE);
-    optpreset (o_propfont (&gw_def_win), DEFAULT_PROPFONT, OPT_REDRAW|OPT_HIDE);
-    optpreset (o_titleformat (&gw_def_win), DEFAULT_TITLEFORMAT, OPT_HIDE);
-    optpreset (o_scrollbgimage (&gw_def_win), ElvTrue, OPT_REDRAW|OPT_HIDE);
+	/* set default values for options */
+	optpreset (o_scrollbar (&gw_def_win), ElvTrue, OPT_REDRAW|OPT_HIDE);
+	optpreset (o_toolbar (&gw_def_win), ElvTrue, OPT_REDRAW|OPT_HIDE);
+	optpreset (o_statusbar (&gw_def_win), ElvTrue, OPT_REDRAW|OPT_HIDE);
+	optpreset (o_menubar (&gw_def_win), ElvTrue, OPT_REDRAW|OPT_HIDE);
+	optpreset (o_font (&gw_def_win), DEFAULT_FONT, OPT_REDRAW|OPT_HIDE);
+	optpreset (o_propfont (&gw_def_win), DEFAULT_PROPFONT, OPT_REDRAW|OPT_HIDE);
+	optpreset (o_titleformat (&gw_def_win), DEFAULT_TITLEFORMAT, OPT_HIDE);
+	optpreset (o_scrollbgimage (&gw_def_win), ElvTrue, OPT_REDRAW|OPT_HIDE);
 
-    /* install the global options */
-    optinsert("win32", QTY(gw_optglob_desc), gw_optglob_desc, gw_optglob_val);
+	/* install the global options */
+	optinsert("win32", QTY(gw_optglob_desc), gw_optglob_desc, gw_optglob_val);
 
-    /* install default options */
-    optinsert("guiwin", NUM_OPTIONS, gw_opt_desc, (OPTVAL *)&gw_def_win.options);
+	/* install default options */
+	optinsert("guiwin", NUM_OPTIONS, gw_opt_desc, (OPTVAL *)&gw_def_win.options);
 
-    /* install the default printer */
-    gw_get_default_printer ();
+	/* install the default printer */
+	gw_get_default_printer ();
 
-    /* install default "normal" colors. */
-    colorinfo[COLOR_FONT_NORMAL].fg = color = GetSysColor(COLOR_WINDOWTEXT);
-    colorinfo[COLOR_FONT_NORMAL].da.fg_rgb[0] = color & 0xff;
-    colorinfo[COLOR_FONT_NORMAL].da.fg_rgb[1] = (color >> 8) & 0xff;
-    colorinfo[COLOR_FONT_NORMAL].da.fg_rgb[2] = (color >> 16) & 0xff;
-    colorinfo[COLOR_FONT_NORMAL].bg = color = GetSysColor(COLOR_WINDOW);
-    colorinfo[COLOR_FONT_NORMAL].da.bg_rgb[0] = color & 0xff;
-    colorinfo[COLOR_FONT_NORMAL].da.bg_rgb[1] = (color >> 8) & 0xff;
-    colorinfo[COLOR_FONT_NORMAL].da.bg_rgb[2] = (color >> 16) & 0xff;
-    colorinfo[COLOR_FONT_NORMAL].da.bits = COLOR_FG|COLOR_BG;
+	/* install default "normal" colors. */
+	colorinfo[COLOR_FONT_NORMAL].fg = color = GetSysColor(COLOR_WINDOWTEXT);
+	colorinfo[COLOR_FONT_NORMAL].da.fg_rgb[0] = color & 0xff;
+	colorinfo[COLOR_FONT_NORMAL].da.fg_rgb[1] = (color >> 8) & 0xff;
+	colorinfo[COLOR_FONT_NORMAL].da.fg_rgb[2] = (color >> 16) & 0xff;
+	colorinfo[COLOR_FONT_NORMAL].bg = color = GetSysColor(COLOR_WINDOW);
+	colorinfo[COLOR_FONT_NORMAL].da.bg_rgb[0] = color & 0xff;
+	colorinfo[COLOR_FONT_NORMAL].da.bg_rgb[1] = (color >> 8) & 0xff;
+	colorinfo[COLOR_FONT_NORMAL].da.bg_rgb[2] = (color >> 16) & 0xff;
+	colorinfo[COLOR_FONT_NORMAL].da.bits = COLOR_FG|COLOR_BG;
 
-    /* locate the "guide" color */
-    guidefont = colorfind("guide");
+	/* locate the "guide" color */
+	guidefont = colorfind("guide");
 
-    return argc;
+	return argc;
 }
 
 /* ------------------------------------------------------------------------
@@ -284,49 +284,49 @@ static int gwinit (int argc, char *argv[])
 
 static void gwloop (void)
 {
-    MSG             msg;
-    GUI_WINDOW      *gwp;
+	MSG             msg;
+	GUI_WINDOW      *gwp;
 
-    /* the default window options aren't editable once we have real windows */
-    optdelete((OPTVAL *)&gw_def_win.options);
+	/* the default window options aren't editable once we have real windows */
+	optdelete((OPTVAL *)&gw_def_win.options);
 
-    /* peform the -c command or -t tag */
-    if (mainfirstcmd(windefault))
-	return;
+	/* peform the -c command or -t tag */
+	if (mainfirstcmd(windefault))
+		return;
 
-    /* if -Gquit, and there were no errors, then try to destroy the windows */
-    if (gui == &guiquit && o_exitcode == 0 && gw_def_win.nextp)
-	eventex(gw_def_win.nextp, "qall", ElvFalse);
+	/* if -Gquit, and there were no errors, then try to destroy the windows */
+	if (gui == &guiquit && o_exitcode == 0 && gw_def_win.nextp)
+		eventex(gw_def_win.nextp, "qall", ElvFalse);
 
-    msg.message = 0;
-    while (gw_def_win.nextp != NULL)
-    {
-	/* NOTE: For some reason, WinElvis receives an incessant stream of
-	 * 0x0118 messages when it should be idle.  I have no idea why, or
-	 * even what 0x0118 means.  I know 0x0117 is WM_ITEMMENUPOPUP and
-	 * 0x011f is WM_MENUSELECT, but 0x0118 isn't defined in <winuser.h>
-	 *
-	 * Those messages are harmless, except that they interfere with the
-	 * blinking of the cursor.  If elvis doesn't update screens after a
-	 * 0x0118 message, then the cursor blinks and everything looks good.
-	 * I wish I know why this is happening, but for now I'm content to
-	 * simply have this work-around.
-	 *
-	 * This behavior is new in 2.2g-beta; it didn't occur in 2.2f-beta.
-	 * I tried restoring the 2.2f versions of the guiwin32/* files, but
-	 * that had no effect.
-	 */
+	msg.message = 0;
+	while (gw_def_win.nextp != NULL)
+	{
+		/* NOTE: For some reason, WinElvis receives an incessant stream of
+		 * 0x0118 messages when it should be idle.  I have no idea why, or
+		 * even what 0x0118 means.  I know 0x0117 is WM_ITEMMENUPOPUP and
+		 * 0x011f is WM_MENUSELECT, but 0x0118 isn't defined in <winuser.h>
+		 *
+		 * Those messages are harmless, except that they interfere with the
+		 * blinking of the cursor.  If elvis doesn't update screens after a
+		 * 0x0118 message, then the cursor blinks and everything looks good.
+		 * I wish I know why this is happening, but for now I'm content to
+		 * simply have this work-around.
+		 *
+		 * This behavior is new in 2.2g-beta; it didn't occur in 2.2f-beta.
+		 * I tried restoring the 2.2f versions of the guiwin32/* files, but
+		 * that had no effect.
+		 */
 
-        /* repaint the windows */
-        if (msg.message != WM_PAINT && msg.message != 0x0118)
-	    for (gwp = gw_def_win.nextp; gwp != NULL; gwp = gwp->nextp)
-		gw_redraw_win (gwp);
+		/* repaint the windows */
+		if (msg.message != WM_PAINT && msg.message != 0x0118)
+			for (gwp = gw_def_win.nextp; gwp != NULL; gwp = gwp->nextp)
+				gw_redraw_win (gwp);
 
-        /* process Windows messages */
-        GetMessage (&msg, NULL, 0, 0);
-	TranslateMessage (&msg);
-	DispatchMessage (&msg);
-    }
+		/* process Windows messages */
+		GetMessage (&msg, NULL, 0, 0);
+		TranslateMessage (&msg);
+		DispatchMessage (&msg);
+	}
 }
 
 
@@ -337,17 +337,17 @@ static void gwloop (void)
 
 static ELVBOOL gwwpoll(ELVBOOL reset)
 {
-    MSG     msg;
+	MSG     msg;
 
-    /* if reset, do nothing */
-    if (reset)
-        return ElvFalse;
+	/* if reset, do nothing */
+	if (reset)
+		return ElvFalse;
 
-    /* check if something on the message queue */
-    if (PeekMessage (&msg, NULL, WM_KEYDOWN, WM_KEYDOWN, PM_NOREMOVE))
-        return ElvTrue;
+	/* check if something on the message queue */
+	if (PeekMessage (&msg, NULL, WM_KEYDOWN, WM_KEYDOWN, PM_NOREMOVE))
+		return ElvTrue;
 
-    return ElvFalse;
+	return ElvFalse;
 }
 
 /* ------------------------------------------------------------------------
@@ -357,8 +357,8 @@ static ELVBOOL gwwpoll(ELVBOOL reset)
 
 static void gwterm(void)
 {
-    if (gwcustomicon)
-	DestroyIcon(gwcustomicon);
+	if (gwcustomicon)
+		DestroyIcon(gwcustomicon);
 }
 
 /* ------------------------------------------------------------------------
@@ -368,86 +368,86 @@ static void gwterm(void)
 
 static ELVBOOL gwcreategw(char *name, char *firstcmd)
 {
-    GUI_WINDOW      *gwp;
-    DWORD           dwStyle = WS_CHILD | WS_CLIPSIBLINGS |
-                              WS_BORDER | WS_VISIBLE;
+	GUI_WINDOW      *gwp;
+	DWORD           dwStyle = WS_CHILD | WS_CLIPSIBLINGS |
+	                          WS_BORDER | WS_VISIBLE;
 
-    /* allocate a new GUI_WINDOW */
-    if ((gwp = calloc (1, sizeof (GUI_WINDOW))) == NULL)
-        return ElvFalse;
-    gwp->nextp = gw_def_win.nextp;
-    gw_def_win.nextp = gwp;
-    gwp->bg = colorinfo[COLOR_FONT_NORMAL].bg;
+	/* allocate a new GUI_WINDOW */
+	if ((gwp = calloc (1, sizeof (GUI_WINDOW))) == NULL)
+		return ElvFalse;
+	gwp->nextp = gw_def_win.nextp;
+	gw_def_win.nextp = gwp;
+	gwp->bg = colorinfo[COLOR_FONT_NORMAL].bg;
 
-    /* set default options */
-    gwp->options = gw_def_win.options;
-    o_font(gwp) = CHARdup(o_font(&gw_def_win));
-    o_propfont(gwp) = CHARdup(o_propfont(&gw_def_win));
-    o_titleformat(gwp) = CHARdup(o_titleformat(&gw_def_win));
+	/* set default options */
+	gwp->options = gw_def_win.options;
+	o_font(gwp) = CHARdup(o_font(&gw_def_win));
+	o_propfont(gwp) = CHARdup(o_propfont(&gw_def_win));
+	o_titleformat(gwp) = CHARdup(o_titleformat(&gw_def_win));
 
-    /* create the Windows windows */
-    gwp->frameHWnd = CreateWindow ("ElvisFrameWnd", "WinElvis",
-                                   WS_OVERLAPPEDWINDOW,
-                                   CW_USEDEFAULT, 0,
-                                   CW_USEDEFAULT, 0,
-                                   NULL, NULL, hInst, NULL);
-    gw_create_toolbar (gwp);
-    gw_create_status_bar (gwp);
-    if (o_scrollbar (gwp))
-        dwStyle |= WS_VSCROLL;
-    gwp->clientHWnd = CreateWindow ("ElvisClientWnd", NULL,
-                                    dwStyle, 0, 0, 0, 0,
-                                    gwp->frameHWnd, NULL, hInst, NULL);
-    gwp->menuHndl = o_menubar (gwp) ?
-                    LoadMenu (hInst, MAKEINTRESOURCE (IDM_ELVIS)) : NULL;
+	/* create the Windows windows */
+	gwp->frameHWnd = CreateWindow ("ElvisFrameWnd", "WinElvis",
+	                               WS_OVERLAPPEDWINDOW,
+	                               CW_USEDEFAULT, 0,
+	                               CW_USEDEFAULT, 0,
+	                               NULL, NULL, hInst, NULL);
+	gw_create_toolbar (gwp);
+	gw_create_status_bar (gwp);
+	if (o_scrollbar (gwp))
+		dwStyle |= WS_VSCROLL;
+	gwp->clientHWnd = CreateWindow ("ElvisClientWnd", NULL,
+	                                dwStyle, 0, 0, 0, 0,
+	                                gwp->frameHWnd, NULL, hInst, NULL);
+	gwp->menuHndl = o_menubar (gwp) ?
+		LoadMenu (hInst, MAKEINTRESOURCE (IDM_ELVIS)) : NULL;
 	SetMenu (gwp->frameHWnd, gwp->menuHndl);
-    if (gwp->menuHndl != NULL)
-        DrawMenuBar (gwp->frameHWnd);
+	if (gwp->menuHndl != NULL)
+		DrawMenuBar (gwp->frameHWnd);
 
-    /* resize client window */
-    SendMessage (gwp->frameHWnd, WM_SIZE, 0, 0);
+	/* resize client window */
+	SendMessage (gwp->frameHWnd, WM_SIZE, 0, 0);
 
-    /* set the cursor */
-    ShowCursor (FALSE);
-    SetCursor (hLeftArrow);
-    ShowCursor (TRUE);
+	/* set the cursor */
+	ShowCursor (FALSE);
+	SetCursor (hLeftArrow);
+	ShowCursor (TRUE);
 
-    /* set the fonts */
-    gw_set_fonts (gwp);
+	/* set the fonts */
+	gw_set_fonts (gwp);
 
-    /* set new title */
-    gwretitle ((GUIWIN *)gwp, name);
+	/* set new title */
+	gwretitle ((GUIWIN *)gwp, name);
 
-    /* set window size */
-    gw_get_win_size (gwp);
-    gw_set_win_size (gwp, 0);
+	/* set window size */
+	gw_get_win_size (gwp);
+	gw_set_win_size (gwp, 0);
 
-    /* tell elvis that we have a new window */
-    eventcreate((GUIWIN *)gwp, &gwp->options.scrollbar, name,
-                gwp->numrows, gwp->numcols);
+	/* tell elvis that we have a new window */
+	eventcreate((GUIWIN *)gwp, &gwp->options.scrollbar, name,
+	            gwp->numrows, gwp->numcols);
 
-    /* make window active */
-    eventfocus((GUIWIN *)gwp, ElvTrue);
-    gwp->active = 1;
+	/* make window active */
+	eventfocus((GUIWIN *)gwp, ElvTrue);
+	gwp->active = 1;
 
-    /* show the window */
-    ShowWindow (gwp->frameHWnd, SW_SHOW);
+	/* show the window */
+	ShowWindow (gwp->frameHWnd, SW_SHOW);
 
-    /* accept dragging of files */
-    DragAcceptFiles (gwp->clientHWnd, TRUE);
+	/* accept dragging of files */
+	DragAcceptFiles (gwp->clientHWnd, TRUE);
 
-    /* disable printing if no printing */
-    if (!gw_printing_ok)
-        gw_disable_printing (gwp);
+	/* disable printing if no printing */
+	if (!gw_printing_ok)
+		gw_disable_printing (gwp);
 
-    /* if there is a firstcmd, then execute it */
-    if (firstcmd)
-    {
-	winoptions(winofgw((GUIWIN *)gwp));
-	exstring(windefault, toCHAR(firstcmd), "+cmd");
-    }
+	/* if there is a firstcmd, then execute it */
+	if (firstcmd)
+	{
+		winoptions(winofgw((GUIWIN *)gwp));
+		exstring(windefault, toCHAR(firstcmd), "+cmd");
+	}
 
-    return ElvTrue;
+	return ElvTrue;
 }
 
 /* ------------------------------------------------------------------------
@@ -458,36 +458,36 @@ static ELVBOOL gwcreategw(char *name, char *firstcmd)
 static void gwdestroygw (GUIWIN *gw, ELVBOOL force)
 
 {
-    GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
-    GUI_WINDOW      *winp;
+	GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
+	GUI_WINDOW      *winp;
 
-    /* not active anymore */
-    DragAcceptFiles (gwp->clientHWnd, FALSE);
-    gwp->active = 0;
+	/* not active anymore */
+	DragAcceptFiles (gwp->clientHWnd, FALSE);
+	gwp->active = 0;
 
-    /* tell elvis that we destroy the window */
-    eventdestroy (gw);
+	/* tell elvis that we destroy the window */
+	eventdestroy (gw);
 
-    /* delete the fonts */
-    gw_del_fonts (gwp);
+	/* delete the fonts */
+	gw_del_fonts (gwp);
 
-    /* destroy the Windows windows */
-    if (gwp->menuHndl != NULL)
-       DestroyMenu (gwp->menuHndl);
-    gw_destroy_toolbar (gwp);
-    gw_destroy_status_bar (gwp);
-    DestroyWindow (gwp->clientHWnd);
-    DestroyWindow (gwp->frameHWnd);
+	/* destroy the Windows windows */
+	if (gwp->menuHndl != NULL)
+		DestroyMenu (gwp->menuHndl);
+	gw_destroy_toolbar (gwp);
+	gw_destroy_status_bar (gwp);
+	DestroyWindow (gwp->clientHWnd);
+	DestroyWindow (gwp->frameHWnd);
 
-    /* reclaim the GUI_WINDOW */
-    for (winp = &gw_def_win; winp->nextp != gwp; winp = winp->nextp)
-        ;
-    winp->nextp = gwp->nextp;
+	/* reclaim the GUI_WINDOW */
+	for (winp = &gw_def_win; winp->nextp != gwp; winp = winp->nextp)
+		;
+	winp->nextp = gwp->nextp;
 
-    safefree (o_font (gwp));
-    safefree (o_propfont (gwp));
-    safefree (o_titleformat (gwp));
-    free (gwp);
+	safefree (o_font (gwp));
+	safefree (o_propfont (gwp));
+	safefree (o_titleformat (gwp));
+	free (gwp);
 }
 
 /* ------------------------------------------------------------------------
@@ -498,12 +498,12 @@ static void gwdestroygw (GUIWIN *gw, ELVBOOL force)
 static ELVBOOL gwfocusgw (GUIWIN *gw)
 
 {
-    GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
+	GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
 
-    /* set the focus to the frame window, will do the rest itself */
-    SetFocus (gwp->frameHWnd);
+	/* set the focus to the frame window, will do the rest itself */
+	SetFocus (gwp->frameHWnd);
 
-    return ElvTrue;
+	return ElvTrue;
 }
 
 /* -----------------------------------------------------------------------
@@ -514,35 +514,35 @@ static ELVBOOL gwfocusgw (GUIWIN *gw)
 static void gwretitle (GUIWIN *gw, char *name)
 
 {
-    GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
+	GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
 #if 0
-    char            title[_MAX_PATH + 20];
-    BUFFER	    buf;
+	char            title[_MAX_PATH + 20];
+	BUFFER	    buf;
 
-    buf = buffind(toCHAR(name));
-    if (buf && o_filename(buf))
-    	name = tochar8(o_filename(buf));
-    sprintf (title, "WinElvis - [%s]", name);
-    SetWindowText (gwp->frameHWnd, title);
+	buf = buffind(toCHAR(name));
+	if (buf && o_filename(buf))
+		name = tochar8(o_filename(buf));
+	sprintf (title, "WinElvis - [%s]", name);
+	SetWindowText (gwp->frameHWnd, title);
 #else
-    Char *argv[2];
-    Char *title;
-    ELVBOOL wasmsg;
+	Char *argv[2];
+	Char *title;
+	ELVBOOL wasmsg;
 
-    /* evaluate the titleformat string */
-    argv[0] = (Char *)name;
-    argv[1] = NULL;
-    title = o_titleformat(gwp);
-    if (!title)
-    	title = (Char *)"$1";
-    wasmsg = msghide(ElvTrue);
-    title = calculate(title, argv, CALC_MSG);
-    msghide(wasmsg);
-    if (title && *title)
-    	name = (char *)title;
+	/* evaluate the titleformat string */
+	argv[0] = (Char *)name;
+	argv[1] = NULL;
+	title = o_titleformat(gwp);
+	if (!title)
+		title = (Char *)"$1";
+	wasmsg = msghide(ElvTrue);
+	title = calculate(title, argv, CALC_MSG);
+	msghide(wasmsg);
+	if (title && *title)
+		name = (char *)title;
 
-    /* change the window's title */
-    SetWindowText (gwp->frameHWnd, name);
+	/* change the window's title */
+	SetWindowText (gwp->frameHWnd, name);
 #endif
 }
 
@@ -554,19 +554,19 @@ static void gwretitle (GUIWIN *gw, char *name)
 static void gwmoveto(GUIWIN *gw, int column, int row)
 
 {
-    GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
-    
-    /* retain current position */
-    gwp->currow = row;
-    gwp->curcol = column;
+	GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
 
-    /* set new position if active view */
-    if (gwp->cursor_type != CURSOR_NONE && gwp->clientHWnd == GetFocus ())
-    {
-	HideCaret (gwp->clientHWnd);
-	gw_set_cursor(gwp, FALSE);
-	ShowCaret (gwp->clientHWnd);
-    }
+	/* retain current position */
+	gwp->currow = row;
+	gwp->curcol = column;
+
+	/* set new position if active view */
+	if (gwp->cursor_type != CURSOR_NONE && gwp->clientHWnd == GetFocus ())
+	{
+		HideCaret (gwp->clientHWnd);
+		gw_set_cursor(gwp, FALSE);
+		ShowCaret (gwp->clientHWnd);
+	}
 }
 
 /* ------------------------------------------------------------------------
@@ -577,213 +577,213 @@ static void gwmoveto(GUIWIN *gw, int column, int row)
 static void gwdraw(GUIWIN *gw, long fg, long bg, int bits, Char *text, int len)
 
 {
-    register int    i;
-    GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
-    COLORREF        fgc, bgc;
-    HBRUSH	    hBrush, hPrevBrush;
-    HPEN            hPen, hPrevPen;
-    HDC		    hDC;
-    HFONT           hFont;
-    RECT            rect;
-    int             ileft;
-    int             xleft, xcenter, xright, ytop, ycenter, ybottom, radius;
-    UINT	    options;
+	register int    i;
+	GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
+	COLORREF        fgc, bgc;
+	HBRUSH          hBrush, hPrevBrush;
+	HPEN            hPen, hPrevPen;
+	HDC             hDC;
+	HFONT           hFont;
+	RECT            rect;
+	int             ileft;
+	int             xleft, xcenter, xright, ytop, ycenter, ybottom, radius;
+	UINT            options;
 
-    /* Italics are slanted rightward from the bottom of the character cell.
-     * We'd like for them to look slanted from the center of the characters,
-     * and we can achieve that effect by shifting italic text slightly leftward.
-     */
-    ileft = 0;
-    if ((bits & COLOR_GRAPHIC) != COLOR_GRAPHIC && (bits & COLOR_ITALIC))
-	ileft = (gwp->ycsize - 3) / 6; /* just a guess */
-  
-    /* Convert fg and bg args into COLORREF values */
-    fgc = (COLORREF)fg;
-    bgc = (COLORREF)bg;
+	/* Italics are slanted rightward from the bottom of the character cell.
+	 * We'd like for them to look slanted from the center of the characters,
+	 * and we can achieve that effect by shifting italic text slightly leftward.
+	 */
+	ileft = 0;
+	if ((bits & COLOR_GRAPHIC) != COLOR_GRAPHIC && (bits & COLOR_ITALIC))
+		ileft = (gwp->ycsize - 3) / 6; /* just a guess */
 
-    /* compute the update RECT */
-    rect.top = gwp->currow * gwp->ycsize;
-    rect.left = gwp->curcol * gwp->xcsize + gwp->xcsize / 2;
-    rect.bottom = rect.top + gwp->ycsize;
-    rect.right = rect.left + gwp->xcsize * len;
+	/* Convert fg and bg args into COLORREF values */
+	fgc = (COLORREF)fg;
+	bgc = (COLORREF)bg;
 
-    /* Get the window's DC */
-    hDC = GetDC (gwp->clientHWnd);
-    SetMapMode (hDC, MM_TEXT);
+	/* compute the update RECT */
+	rect.top = gwp->currow * gwp->ycsize;
+	rect.left = gwp->curcol * gwp->xcsize + gwp->xcsize / 2;
+	rect.bottom = rect.top + gwp->ycsize;
+	rect.right = rect.left + gwp->xcsize * len;
 
-    /* hide caret */
-    if (gwp->cursor_type != CURSOR_NONE && gwp->clientHWnd == GetFocus ())
-    {
-	HideCaret (gwp->clientHWnd);
-	gwp->cursor_type = CURSOR_NONE;
-    }
+	/* Get the window's DC */
+	hDC = GetDC (gwp->clientHWnd);
+	SetMapMode (hDC, MM_TEXT);
 
-    /* graphic chars are a special case */
-    if ((bits & COLOR_GRAPHIC) == COLOR_GRAPHIC)
-    {
-	/* Strip out the COLOR_GRAPHIC bits */
-	bits &= ~COLOR_GRAPHIC;
-
-	/* Erase the area */
-#ifdef FEATURE_IMAGE
-	if (normalimage && (long)bgc == colorinfo[COLOR_FONT_NORMAL].bg)
+	/* hide caret */
+	if (gwp->cursor_type != CURSOR_NONE && gwp->clientHWnd == GetFocus ())
 	{
-	    gw_erase_rect(hDC, &rect, normalimage, gwp->scrolled);
+		HideCaret (gwp->clientHWnd);
+		gwp->cursor_type = CURSOR_NONE;
 	}
-	else if (idleimage && (long)bgc == colorinfo[COLOR_FONT_IDLE].bg)
+
+	/* graphic chars are a special case */
+	if ((bits & COLOR_GRAPHIC) == COLOR_GRAPHIC)
 	{
-	    gw_erase_rect(hDC, &rect, idleimage, gwp->scrolled);
+		/* Strip out the COLOR_GRAPHIC bits */
+		bits &= ~COLOR_GRAPHIC;
+
+		/* Erase the area */
+#ifdef FEATURE_IMAGE
+		if (normalimage && (long)bgc == colorinfo[COLOR_FONT_NORMAL].bg)
+		{
+			gw_erase_rect(hDC, &rect, normalimage, gwp->scrolled);
+		}
+		else if (idleimage && (long)bgc == colorinfo[COLOR_FONT_IDLE].bg)
+		{
+			gw_erase_rect(hDC, &rect, idleimage, gwp->scrolled);
+		}
+		else
+#endif
+		{
+			hBrush = CreateSolidBrush (bgc);
+			FillRect (hDC, &rect, hBrush);
+			DeleteObject(hBrush);
+		}
+
+		/* Select the foreground color */
+		hPen = CreatePen(PS_SOLID, 0, fgc);
+		hPrevPen = SelectObject(hDC, hPen);
+
+		/* Find special points in the first character cell */
+		radius = gwp->xcsize / 3;
+		xleft = rect.left;
+		xright = xleft + gwp->xcsize;
+		xcenter = (xleft + xright) / 2;
+		ytop = rect.top;
+		ybottom = rect.bottom;
+		ycenter = (ytop + ybottom) / 2;
+
+		/* For each graphic character... */
+		for (i = 0; i < len; text++, i++)
+		{
+			/* Draw line segments, as appropriate for this character */
+			if (strchr("123456|", *text))
+			{
+				MoveToEx(hDC, xcenter, ytop, NULL);
+				LineTo(hDC, xcenter, ycenter);
+			}
+			if (strchr("456789|", *text))
+			{
+				MoveToEx(hDC, xcenter, ycenter, NULL);
+				LineTo(hDC, xcenter, ybottom);
+			}
+			if (strchr("235689-", *text))
+			{
+				MoveToEx(hDC, xleft, ycenter, NULL);
+				LineTo(hDC, xcenter, ycenter);
+			}
+			if (strchr("124578-", *text))
+			{
+				MoveToEx(hDC, xcenter, ycenter, NULL);
+				LineTo(hDC, xright, ycenter);
+			}
+			if (*text == 'o')
+			{
+				Arc(hDC, xcenter - radius, ycenter - radius,
+				xcenter + radius, ycenter + radius,
+				xcenter - radius, ycenter,  xcenter - radius, ycenter);
+			}
+			if (*text == '*')
+			{
+				HBRUSH	oldbrush, newbrush;
+				newbrush = CreateSolidBrush(fgc);
+				oldbrush = SelectObject(hDC, newbrush);
+				Pie(hDC, xcenter - radius, ycenter - radius,
+				xcenter + radius, ycenter + radius,
+				xcenter - radius, ycenter,  xcenter - radius, ycenter);
+				SelectObject(hDC, oldbrush);
+				DeleteObject(newbrush);
+			}
+
+			/* Advance the points to the next cell */
+			xleft = xright;
+			xcenter += gwp->xcsize;
+			xright += gwp->xcsize;
+		}
+
+		/* Restore foreground color to its previous value, so we can delete
+		 * the local hPen object.
+		 */
+		SelectObject(hDC, hPrevPen);
+		DeleteObject(hPen);
 	}
 	else
-#endif
 	{
-	    hBrush = CreateSolidBrush (bgc);
-	    FillRect (hDC, &rect, hBrush);
-	    DeleteObject(hBrush);
-	}
+		/* Find a font with the right bold/italic/underlined attributes */
+		i = 0;
+		if (bits & COLOR_BOLD) i += 1;
+		if (bits & COLOR_ITALIC) i += 2;
+		if (bits & COLOR_UNDERLINED) i += 4;
+		hFont = gwp->fonts[i];
 
-	/* Select the foreground color */
-	hPen = CreatePen(PS_SOLID, 0, fgc);
-	hPrevPen = SelectObject(hDC, hPen);
-
-	/* Find special points in the first character cell */
-	radius = gwp->xcsize / 3;
-	xleft = rect.left;
-	xright = xleft + gwp->xcsize;
-	xcenter = (xleft + xright) / 2;
-	ytop = rect.top;
-	ybottom = rect.bottom;
-	ycenter = (ytop + ybottom) / 2;
-
-	/* For each graphic character... */
-	for (i = 0; i < len; text++, i++)
-	{
-	    /* Draw line segments, as appropriate for this character */
-	    if (strchr("123456|", *text))
-	    {
-		MoveToEx(hDC, xcenter, ytop, NULL);
-		LineTo(hDC, xcenter, ycenter);
-	    }
-	    if (strchr("456789|", *text))
-	    {
-		MoveToEx(hDC, xcenter, ycenter, NULL);
-		LineTo(hDC, xcenter, ybottom);
-	    }
-	    if (strchr("235689-", *text))
-	    {
-		MoveToEx(hDC, xleft, ycenter, NULL);
-		LineTo(hDC, xcenter, ycenter);
-	    }
-	    if (strchr("124578-", *text))
-	    {
-		MoveToEx(hDC, xcenter, ycenter, NULL);
-		LineTo(hDC, xright, ycenter);
-	    }
-	    if (*text == 'o')
-	    {
-		Arc(hDC, xcenter - radius, ycenter - radius,
-			xcenter + radius, ycenter + radius,
-			xcenter - radius, ycenter,  xcenter - radius, ycenter);
-	    }
-	    if (*text == '*')
-	    {
-		HBRUSH	oldbrush, newbrush;
-		newbrush = CreateSolidBrush(fgc);
-		oldbrush = SelectObject(hDC, newbrush);
-		Pie(hDC, xcenter - radius, ycenter - radius,
-			xcenter + radius, ycenter + radius,
-			xcenter - radius, ycenter,  xcenter - radius, ycenter);
-		SelectObject(hDC, oldbrush);
-		DeleteObject(newbrush);
-	    }
-
-	    /* Advance the points to the next cell */
-	    xleft = xright;
-	    xcenter += gwp->xcsize;
-	    xright += gwp->xcsize;
-	}
-
-	/* Restore foreground color to its previous value, so we can delete
-	 * the local hPen object.
-	 */
-	SelectObject(hDC, hPrevPen);
-	DeleteObject(hPen);
-    }
-    else
-    {
-	/* Find a font with the right bold/italic/underlined attributes */
-	i = 0;
-	if (bits & COLOR_BOLD) i += 1;
-	if (bits & COLOR_ITALIC) i += 2;
-	if (bits & COLOR_UNDERLINED) i += 4;
-	hFont = gwp->fonts[i];
-
-	/* prepare DC & output text */
-	SetTextColor(hDC, fgc);
-	SetBkColor(hDC, bgc);
-	SetBkMode(hDC, OPAQUE);
-	SelectObject(hDC, hFont);
-	options = ETO_OPAQUE | ETO_CLIPPED;
+		/* prepare DC & output text */
+		SetTextColor(hDC, fgc);
+		SetBkColor(hDC, bgc);
+		SetBkMode(hDC, OPAQUE);
+		SelectObject(hDC, hFont);
+		options = ETO_OPAQUE | ETO_CLIPPED;
 #ifdef FEATURE_IMAGE
-	if (normalimage && (long)bgc == colorinfo[COLOR_FONT_NORMAL].bg)
-	{
-	    gw_erase_rect(hDC, &rect, normalimage, gwp->scrolled);
-	    options = ETO_CLIPPED;
-	    SetBkMode(hDC, TRANSPARENT);
-	}
-	else if (idleimage && (long)bgc == colorinfo[COLOR_FONT_IDLE].bg)
-	{
-	    gw_erase_rect(hDC, &rect, idleimage, gwp->scrolled);
-	    options = ETO_CLIPPED;
-	    SetBkMode(hDC, TRANSPARENT);
-	}
+		if (normalimage && (long)bgc == colorinfo[COLOR_FONT_NORMAL].bg)
+		{
+			gw_erase_rect(hDC, &rect, normalimage, gwp->scrolled);
+			options = ETO_CLIPPED;
+			SetBkMode(hDC, TRANSPARENT);
+		}
+		else if (idleimage && (long)bgc == colorinfo[COLOR_FONT_IDLE].bg)
+		{
+			gw_erase_rect(hDC, &rect, idleimage, gwp->scrolled);
+			options = ETO_CLIPPED;
+			SetBkMode(hDC, TRANSPARENT);
+		}
 #endif
-	ExtTextOut(hDC, rect.left - ileft, rect.top, options, &rect,
-	    (char *)text, len, gwp->font_size_array);
+		ExtTextOut(hDC, rect.left - ileft, rect.top, options, &rect,
+			(char *)text, len, gwp->font_size_array);
 #ifdef FEATURE_IMAGE
-	SetBkColor(hDC, bgc);
-	SetBkMode(hDC, OPAQUE);
+		SetBkColor(hDC, bgc);
+		SetBkMode(hDC, OPAQUE);
 #endif
-    }
-
-    /* If COLOR_BOXED then draw a rectangle around the text */
-    if (bits & (COLOR_BOXED | COLOR_LEFTBOX | COLOR_RIGHTBOX))
-    {
-	/* Select the foreground color */
-	hPen = CreatePen(PS_SOLID, 0, fgc);
-	hPrevPen = SelectObject(hDC, hPen);
-
-	/* Draw the rectangle */
-	if (bits & COLOR_BOXED)
-	{
-	    MoveToEx(hDC, rect.left, rect.top, NULL);
-	    LineTo(hDC, rect.right, rect.top);
-	    MoveToEx(hDC, rect.left, rect.bottom - 1, NULL);
-	    LineTo(hDC, rect.right, rect.bottom - 1);
-	}
-        if (bits & COLOR_RIGHTBOX)
-	{
-	    MoveToEx(hDC, rect.right - 1, rect.top, NULL);
-	    LineTo(hDC, rect.right - 1, rect.bottom);
-	}
-        if (bits & COLOR_LEFTBOX)
-	{
-	    MoveToEx(hDC, rect.left, rect.top, NULL);
-	    LineTo(hDC, rect.left, rect.bottom);
 	}
 
-	/* Restore foreground color to its previous value, so we can delete
-	 * the local hPen object.
-	 */
-	SelectObject(hDC, hPrevPen);
-	DeleteObject(hPen);
-    }
+	/* If COLOR_BOXED then draw a rectangle around the text */
+	if (bits & (COLOR_BOXED | COLOR_LEFTBOX | COLOR_RIGHTBOX))
+	{
+		/* Select the foreground color */
+		hPen = CreatePen(PS_SOLID, 0, fgc);
+		hPrevPen = SelectObject(hDC, hPen);
 
-    /* release the window's device context */
-    ReleaseDC(gwp->clientHWnd, hDC);
+		/* Draw the rectangle */
+		if (bits & COLOR_BOXED)
+		{
+			MoveToEx(hDC, rect.left, rect.top, NULL);
+			LineTo(hDC, rect.right, rect.top);
+			MoveToEx(hDC, rect.left, rect.bottom - 1, NULL);
+			LineTo(hDC, rect.right, rect.bottom - 1);
+		}
+			if (bits & COLOR_RIGHTBOX)
+		{
+			MoveToEx(hDC, rect.right - 1, rect.top, NULL);
+			LineTo(hDC, rect.right - 1, rect.bottom);
+		}
+			if (bits & COLOR_LEFTBOX)
+		{
+			MoveToEx(hDC, rect.left, rect.top, NULL);
+			LineTo(hDC, rect.left, rect.bottom);
+		}
 
-    /* update cursor position */
-    gwp->curcol += len;
+		/* Restore foreground color to its previous value, so we can delete
+		 * the local hPen object.
+		 */
+		SelectObject(hDC, hPrevPen);
+		DeleteObject(hPen);
+	}
+
+	/* release the window's device context */
+	ReleaseDC(gwp->clientHWnd, hDC);
+
+	/* update cursor position */
+	gwp->curcol += len;
 }
 
 /* ------------------------------------------------------------------------
@@ -794,44 +794,44 @@ static void gwdraw(GUIWIN *gw, long fg, long bg, int bits, Char *text, int len)
 static ELVBOOL gwscroll (GUIWIN *gw, int qty, ELVBOOL notlast)
 
 {
-    GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
-    int             rows = gwp->numrows - gwp->currow;
-    RECT            rect;
+	GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
+	int             rows = gwp->numrows - gwp->currow;
+	RECT            rect;
 
 #ifdef FEATURE_IMAGE
-    /* if we're using background images, then don't scroll because it would
-     * shred the background image.
-     */
-    if ((normalimage || idleimage)
-     && (!o_scrollbgimage(gwp) || gwp->currow != 0 || !notlast))
-	return ElvFalse;
+	/* if we're using background images, then don't scroll because it would
+	 * shred the background image.
+	 */
+	if ((normalimage || idleimage)
+		&& (!o_scrollbgimage(gwp) || gwp->currow != 0 || !notlast))
+		return ElvFalse;
 
-    /* adjust the number of scrolled pixels, for the background image */
-    gwp->scrolled -= qty * gwp->ycsize;
+	/* adjust the number of scrolled pixels, for the background image */
+	gwp->scrolled -= qty * gwp->ycsize;
 #endif
 
-    /* adjust number of rows */
-    if (notlast)
-        rows--;
+	/* adjust number of rows */
+	if (notlast)
+		rows--;
 
-    /* compute update RECT */
-    rect.top = gwp->currow * gwp->ycsize;
-    rect.left = 0;
-    rect.bottom = rect.top + rows * gwp->ycsize;
-    rect.right = gwp->xsize;
+	/* compute update RECT */
+	rect.top = gwp->currow * gwp->ycsize;
+	rect.left = 0;
+	rect.bottom = rect.top + rows * gwp->ycsize;
+	rect.right = gwp->xsize;
 
-    /* hide caret */
-    if (gwp->cursor_type != CURSOR_NONE && gwp->clientHWnd == GetFocus())
-    {
-	HideCaret (gwp->clientHWnd);
-	gwp->cursor_type = CURSOR_NONE;
-    }
+	/* hide caret */
+	if (gwp->cursor_type != CURSOR_NONE && gwp->clientHWnd == GetFocus())
+	{
+		HideCaret (gwp->clientHWnd);
+		gwp->cursor_type = CURSOR_NONE;
+	}
 
-    /* scroll window */
-    ScrollWindowEx (gwp->clientHWnd, 0, qty * gwp->ycsize, &rect,
-                    &rect, NULL, NULL, SW_INVALIDATE);
+	/* scroll window */
+	ScrollWindowEx (gwp->clientHWnd, 0, qty * gwp->ycsize, &rect,
+	                &rect, NULL, NULL, SW_INVALIDATE);
 
-    return ElvTrue;
+	return ElvTrue;
 }
 
 /* ------------------------------------------------------------------------
@@ -842,48 +842,48 @@ static ELVBOOL gwscroll (GUIWIN *gw, int qty, ELVBOOL notlast)
 static ELVBOOL gwclrtoeol(GUIWIN *gw)
 
 {
-    GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
-    RECT            rect;
-    HBRUSH	    brush;
-    HDC		    hDC;
+	GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
+	RECT            rect;
+	HBRUSH	    brush;
+	HDC		    hDC;
 
-    /* compute update RECT */
-    rect.top = gwp->currow * gwp->ycsize;
-    rect.left = gwp->curcol * gwp->xcsize + gwp->xcsize / 2;
-    rect.bottom = rect.top + gwp->ycsize;
-    rect.right = gwp->xsize;
+	/* compute update RECT */
+	rect.top = gwp->currow * gwp->ycsize;
+	rect.left = gwp->curcol * gwp->xcsize + gwp->xcsize / 2;
+	rect.bottom = rect.top + gwp->ycsize;
+	rect.right = gwp->xsize;
 
-    /* hide caret */
-    if (gwp->cursor_type != CURSOR_NONE && gwp->clientHWnd == GetFocus ())
-    {
-	HideCaret (gwp->clientHWnd);
-	gwp->cursor_type = CURSOR_NONE;
-    }
+	/* hide caret */
+	if (gwp->cursor_type != CURSOR_NONE && gwp->clientHWnd == GetFocus ())
+	{
+		HideCaret (gwp->clientHWnd);
+		gwp->cursor_type = CURSOR_NONE;
+	}
 
-    /* get the window's DC */
-    hDC = GetDC (gwp->clientHWnd);
-    SetMapMode (hDC, MM_TEXT);
+	/* get the window's DC */
+	hDC = GetDC (gwp->clientHWnd);
+	SetMapMode (hDC, MM_TEXT);
 
 #ifdef FEATURE_IMAGE
-    if (normalimage && (long)gwp->bg == colorinfo[COLOR_FONT_NORMAL].bg)
-    {
-	gw_erase_rect(hDC, &rect, normalimage, gwp->scrolled);
-    }
-    else if (idleimage && (long)gwp->bg == colorinfo[COLOR_FONT_IDLE].bg)
-    {
+	if (normalimage && (long)gwp->bg == colorinfo[COLOR_FONT_NORMAL].bg)
+	{
+		gw_erase_rect(hDC, &rect, normalimage, gwp->scrolled);
+	}
+	else if (idleimage && (long)gwp->bg == colorinfo[COLOR_FONT_IDLE].bg)
+		{
 	gw_erase_rect(hDC, &rect, idleimage, gwp->scrolled);
-    }
-    else
+	}
+	else
 #endif
-    {
+	{
 	/* fill the rectangle with the bg color */
-	brush = CreateSolidBrush(gwp->bg);
-	FillRect (hDC, &rect, brush);
-	DeleteObject(brush);
-    }
+		brush = CreateSolidBrush(gwp->bg);
+		FillRect (hDC, &rect, brush);
+		DeleteObject(brush);
+	}
 
-    ReleaseDC(gwp->clientHWnd, hDC);
-    return ElvTrue;
+	ReleaseDC(gwp->clientHWnd, hDC);
+	return ElvTrue;
 }
 
 /* ------------------------------------------------------------------------
@@ -894,16 +894,16 @@ static ELVBOOL gwclrtoeol(GUIWIN *gw)
 static void gwbeep (GUIWIN *gw)
 
 {
-    GUI_WINDOW	*gwp = (GUI_WINDOW *)gw;
+	GUI_WINDOW	*gwp = (GUI_WINDOW *)gw;
 
-    if (o_flash && gw != (GUIWIN *)1)
-    {
-	FlashWindow(gwp->frameHWnd, TRUE);
-	Sleep(100);
-	FlashWindow(gwp->frameHWnd, FALSE);
-    }
-    else
-	MessageBeep (MB_OK);
+	if (o_flash && gw != (GUIWIN *)1)
+	{
+		FlashWindow(gwp->frameHWnd, TRUE);
+		Sleep(100);
+		FlashWindow(gwp->frameHWnd, FALSE);
+	}
+	else
+		MessageBeep (MB_OK);
 }
 
 /* ------------------------------------------------------------------------
@@ -914,50 +914,50 @@ static void gwbeep (GUIWIN *gw)
 static void gwscrollbar(GUIWIN *gw, long top, long bottom, long total)
 
 {
-    GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
+	GUI_WINDOW      *gwp = (GUI_WINDOW *)gw;
 #if defined (SIF_ALL)
-    SCROLLINFO      scrollinfo;
+	SCROLLINFO      scrollinfo;
 #endif
 
-    if (!o_scrollbar (gwp))
-        return;
+	if (!o_scrollbar (gwp))
+		return;
 
-    /* Prescale to make total < 65535, to work around Win32 limit */
-    while (total >= 65535)
-    {
-	top >>= 1;
-	bottom >>= 1;
-	total >>= 1;
-    }
+	/* Prescale to make total < 65535, to work around Win32 limit */
+	while (total >= 65535)
+	{
+		top >>= 1;
+		bottom >>= 1;
+		total >>= 1;
+	}
 
-    if (total < gwp->numrows || bottom <= 0)
-    {
-        total = gwp->numrows;
-        top = 0;
-	bottom = total - 1;
-    }
-    if (top == 0 && bottom >= total) /* Weird bug in Win32? */
-	bottom = total - 1;
-    gwp->scrollsize = total;
+	if (total < gwp->numrows || bottom <= 0)
+	{
+		total = gwp->numrows;
+		top = 0;
+		bottom = total - 1;
+	}
+	if (top == 0 && bottom >= total) /* Weird bug in Win32? */
+		bottom = total - 1;
+	gwp->scrollsize = total;
 
 #if defined (SIF_ALL)
-    scrollinfo.cbSize = sizeof (scrollinfo);
-    scrollinfo.fMask = SIF_ALL;
-    scrollinfo.nMin = 0;
-    scrollinfo.nMax = total;
-    scrollinfo.nPos = top;
-    scrollinfo.nPage = bottom - top + 1; /* "+1" is because nMin=0 */
-    if (scrollinfo.nPage > (unsigned)total)
-	scrollinfo.nPage = (unsigned)total + 1; /* "+1" is because nMin=0 */
-    scrollinfo.nTrackPos = top;
-    gwp->thumbsize = scrollinfo.nPage;
-    SetScrollInfo (gwp->clientHWnd, SB_VERT, &scrollinfo, TRUE);
-    if (o_verbose >= 3)
-	msg(MSG_STATUS, "[ddd], nMin=0, nMax=$1, nPage=$2, nPos=$3",
-	(long)scrollinfo.nMax, (long)scrollinfo.nPage, (long)scrollinfo.nPos);
+	scrollinfo.cbSize = sizeof (scrollinfo);
+	scrollinfo.fMask = SIF_ALL;
+	scrollinfo.nMin = 0;
+	scrollinfo.nMax = total;
+	scrollinfo.nPos = top;
+	scrollinfo.nPage = bottom - top + 1; /* "+1" is because nMin=0 */
+	if (scrollinfo.nPage > (unsigned)total)
+		scrollinfo.nPage = (unsigned)total + 1; /* "+1" is because nMin=0 */
+	scrollinfo.nTrackPos = top;
+	gwp->thumbsize = scrollinfo.nPage;
+	SetScrollInfo (gwp->clientHWnd, SB_VERT, &scrollinfo, TRUE);
+	if (o_verbose >= 3)
+		msg(MSG_STATUS, "[ddd], nMin=0, nMax=$1, nPage=$2, nPos=$3",
+		    (long)scrollinfo.nMax, (long)scrollinfo.nPage, (long)scrollinfo.nPos);
 #else /* Win16, or Win32 with MSVC++ 2.0 */
-    SetScrollRange (gwp->clientHWnd, SB_VERT, 0, total, FALSE);
-    SetScrollPos (gwp->clientHWnd, SB_VERT, top, TRUE);
+	SetScrollRange (gwp->clientHWnd, SB_VERT, 0, total, FALSE);
+	SetScrollPos (gwp->clientHWnd, SB_VERT, top, TRUE);
 #endif
 }
 
@@ -968,13 +968,13 @@ static void gwscrollbar(GUIWIN *gw, long top, long bottom, long total)
 static ELVBOOL gwstatus (GUIWIN *gw, Char *cmd, long line, long column, _CHAR_ learn, char *mode)
 
 {
-    GUI_WINDOW       *gwp = (GUI_WINDOW *)gw;
+	GUI_WINDOW       *gwp = (GUI_WINDOW *)gw;
 
-    if (!o_statusbar (gwp))
-        return ElvFalse;
+	if (!o_statusbar (gwp))
+		return ElvFalse;
 
-    gw_upd_status_bar (gwp, cmd, line, column, (char)learn, mode);
-    return ElvTrue;
+	gw_upd_status_bar (gwp, cmd, line, column, (char)learn, mode);
+	return ElvTrue;
 }
 
 /* ------------------------------------------------------------------------
@@ -985,24 +985,24 @@ static ELVBOOL gwstatus (GUIWIN *gw, Char *cmd, long line, long column, _CHAR_ l
 static int gwkeylabel (Char *given, int givenlen, Char **label, Char **rawptr)
 
 {
-    register int        i;
+	register int        i;
 
-    /* compare the given text to each key's strings */
-    for (i = 0; gwkeys[i].label != 0; i++) {
-    
-        /* does given string match key label or raw characters? */
-        if ((!strncmp (gwkeys[i].label, tochar8 (given), (size_t)givenlen) && !gwkeys[i].label[givenlen])
-         || (!strncmp (gwkeys[i].rawin, tochar8 (given), (size_t)givenlen) && !gwkeys[i].rawin[givenlen]))
-        {
+	/* compare the given text to each key's strings */
+	for (i = 0; gwkeys[i].label != 0; i++) {
 
-            /* Set the label and rawptr pointers, return rawlen */
-            *label = (unsigned char *)gwkeys[i].label;
-            *rawptr = (unsigned char *)gwkeys[i].rawin;
-            return strlen ((char *)*rawptr);
-        }
-    }
+		/* does given string match key label or raw characters? */
+		if ((!strncmp (gwkeys[i].label, tochar8 (given), (size_t)givenlen) && !gwkeys[i].label[givenlen])
+		 || (!strncmp (gwkeys[i].rawin, tochar8 (given), (size_t)givenlen) && !gwkeys[i].rawin[givenlen]))
+		{
 
-   return 0;
+			/* Set the label and rawptr pointers, return rawlen */
+			*label = (unsigned char *)gwkeys[i].label;
+			*rawptr = (unsigned char *)gwkeys[i].rawin;
+			return strlen ((char *)*rawptr);
+		}
+	}
+
+	return 0;
 }
 
 /* ------------------------------------------------------------------------
@@ -1013,41 +1013,41 @@ static int gwkeylabel (Char *given, int givenlen, Char **label, Char **rawptr)
 static ELVBOOL gwclipopen (ELVBOOL forwrite)
 
 {
-    GUI_WINDOW      *gwp;
-    BUFFER          buf = cutbuffer ('>', ElvFalse);
+	GUI_WINDOW      *gwp;
+	BUFFER          buf = cutbuffer ('>', ElvFalse);
 
-    /* check is something to do */
-    if (!forwrite &&
-        !IsClipboardFormatAvailable (CF_TEXT) &&
-        !IsClipboardFormatAvailable (CF_OEMTEXT))
-        return ElvFalse;
+	/* check is something to do */
+	if (!forwrite &&
+		!IsClipboardFormatAvailable (CF_TEXT) &&
+		!IsClipboardFormatAvailable (CF_OEMTEXT))
+		return ElvFalse;
 
-    if (forwrite && buf == NULL)
-        return ElvFalse;
+	if (forwrite && buf == NULL)
+		return ElvFalse;
 
-    /* get the active view */
-    if ((gwp = gw_find_client (GetFocus ())) == NULL)
-        return ElvFalse;
+	/* get the active view */
+	if ((gwp = gw_find_client (GetFocus ())) == NULL)
+		return ElvFalse;
 
-    /* open the clipboard */
-    if (!OpenClipboard (gwp->clientHWnd))
-        return ElvFalse;
+	/* open the clipboard */
+	if (!OpenClipboard (gwp->clientHWnd))
+		return ElvFalse;
 
-    /* allocate memory if writing */
+	/* allocate memory if writing */
 	if (forwrite) {
-        clip_len = o_bufchars (buf) + o_buflines (buf) + 1;
-        clip_hGlob = GlobalAlloc (GMEM_MOVEABLE | GMEM_DDESHARE,
-                                  (DWORD)clip_len + 1);
-        if (clip_hGlob == NULL)
-            return ElvFalse;
+		clip_len = o_bufchars (buf) + o_buflines (buf) + 1;
+		clip_hGlob = GlobalAlloc (GMEM_MOVEABLE | GMEM_DDESHARE,
+		                          (DWORD)clip_len + 1);
+		if (clip_hGlob == NULL)
+			return ElvFalse;
 
-        clip_data = (char *)GlobalLock (clip_hGlob);
-        clip_offset = 0;
-        EmptyClipboard ();
-    }
+		clip_data = (char *)GlobalLock (clip_hGlob);
+		clip_offset = 0;
+		EmptyClipboard ();
+	}
 
-    /* indicate success */
-    return ElvTrue;
+	/* indicate success */
+	return ElvTrue;
 }
 
 /* -----------------------------------------------------------------------
@@ -1058,20 +1058,20 @@ static ELVBOOL gwclipopen (ELVBOOL forwrite)
 static int gwclipwrite (Char *text, int len)
 
 {
-    register char       *p = clip_data + clip_offset;
-    register int        numchars = len;
+	register char       *p = clip_data + clip_offset;
+	register int        numchars = len;
 
-    /* fill the allocated memory block */
-    while (numchars-- > 0) {
-        if (*text == '\n') {
-            *p++ = '\r';
-            clip_offset++;
-        }
-        *p++ = *text++;
-        clip_offset++;
-    }
+	/* fill the allocated memory block */
+	while (numchars-- > 0) {
+		if (*text == '\n') {
+			*p++ = '\r';
+			clip_offset++;
+		}
+		*p++ = *text++;
+		clip_offset++;
+	}
 
-    return len;
+	return len;
 }
 
 /* ------------------------------------------------------------------------
@@ -1082,38 +1082,38 @@ static int gwclipwrite (Char *text, int len)
 static int gwclipread (Char *text, int len)
 
 {
-    register char       *p;
-    register int        numchars = 0;
+	register char       *p;
+	register int        numchars = 0;
 
-    /* first time, rerieve memory block */
-    if (clip_hGlob == NULL) {
-        if ((clip_hGlob = GetClipboardData (CF_TEXT)) == NULL && 
-            (clip_hGlob = GetClipboardData (CF_OEMTEXT)) == NULL)
-                return 0;
-        
-        clip_data = (char *)GlobalLock (clip_hGlob);
-        clip_len = strlen (clip_data) - 1;
-        clip_offset = 0;
-    }
+	/* first time, rerieve memory block */
+	if (clip_hGlob == NULL) {
+		if ((clip_hGlob = GetClipboardData (CF_TEXT)) == NULL && 
+			(clip_hGlob = GetClipboardData (CF_OEMTEXT)) == NULL)
+				return 0;
+		
+		clip_data = (char *)GlobalLock (clip_hGlob);
+		clip_len = strlen (clip_data) - 1;
+		clip_offset = 0;
+	}
 
-    /* fill caller's data */
-    for (p = clip_data + clip_offset; *p != '\0'; p++) {
-        if (numchars == len)
-            break;
-        if (*p != '\r') {
-            *text++ = *p;
-            numchars++;
-        }
-        clip_offset++;
-    }
+	/* fill caller's data */
+	for (p = clip_data + clip_offset; *p != '\0'; p++) {
+		if (numchars == len)
+			break;
+		if (*p != '\r') {
+			*text++ = *p;
+			numchars++;
+		}
+		clip_offset++;
+	}
 
-    /* unlock global memory when done */
-    if (numchars == 0) {
-        GlobalUnlock (clip_hGlob);
-        clip_hGlob = 0;
-    }
+	/* unlock global memory when done */
+	if (numchars == 0) {
+		GlobalUnlock (clip_hGlob);
+		clip_hGlob = 0;
+	}
 
-    return numchars;
+	return numchars;
 }
 
 /* ------------------------------------------------------------------------
@@ -1124,16 +1124,16 @@ static int gwclipread (Char *text, int len)
 static void gwclipclose (void)
 
 {
-    /* write to clipboard if writing */
-    if (clip_hGlob != NULL) {
-	clip_data[clip_offset] = '\0'; /* !!! */
-        GlobalUnlock (clip_hGlob);
+	/* write to clipboard if writing */
+	if (clip_hGlob != NULL) {
+		clip_data[clip_offset] = '\0'; /* !!! */
+		GlobalUnlock (clip_hGlob);
 		SetClipboardData (CF_TEXT, clip_hGlob);
-        clip_hGlob = NULL;
-    }
+		clip_hGlob = NULL;
+	}
 
-    /* close the clipboard */
-    CloseClipboard ();
+	/* close the clipboard */
+	CloseClipboard ();
 }
 
 /* ------------------------------------------------------------------------
@@ -1143,183 +1143,183 @@ static void gwclipclose (void)
 
 static ELVBOOL gwcolor (int fontcode, Char *colornam, ELVBOOL isfg, long *colorptr, unsigned char rgb[3])
 {
-    register int        i, j;
-    int			r, g, b;
-    char		*rgbfile;
-    char		rgbname[100];
-    FILE		*fp;
+	register int        i, j;
+	int			r, g, b;
+	char		*rgbfile;
+	char		rgbname[100];
+	FILE		*fp;
 #ifdef FEATURE_IMAGE
-    HBITMAP		newimg;
-    long		average;
-    char		*imagefile;
+	HBITMAP		newimg;
+	long		average;
+	char		*imagefile;
 
-    /* split the name into a "colornam" part and an "imagefile" part */
-    imagefile = colornam;
-    if (*imagefile == '#')
-	imagefile++;
-    while (*imagefile && !elvpunct(*imagefile))
-	imagefile++;
-    while (*imagefile && imagefile > colornam && !elvspace(*imagefile))
-	imagefile--;
-    if (!*imagefile)
-	imagefile = NULL;
-    else if (imagefile > colornam)
-	*imagefile++ = '\0';
-    else
-	colornam = "";
+	/* split the name into a "colornam" part and an "imagefile" part */
+	imagefile = colornam;
+	if (*imagefile == '#')
+		imagefile++;
+	while (*imagefile && !elvpunct(*imagefile))
+		imagefile++;
+	while (*imagefile && imagefile > colornam && !elvspace(*imagefile))
+		imagefile--;
+	if (!*imagefile)
+		imagefile = NULL;
+	else if (imagefile > colornam)
+		*imagefile++ = '\0';
+	else
+		colornam = "";
 #endif
 
-    /* parse the color name */
-    if (*colornam == '#')
-    {
-	/* Accept X11's "#rrggbb" or "#rgb" notations */
-	if (sscanf(tochar8(colornam), "#%2x%*2x%2x%*2x%2x", &r, &g, &b) == 3)
-	    /* do nothing */;
-	else if (sscanf(tochar8(colornam), "#%2x%2x%2x", &r, &g, &b) == 3)
-	    /* do nothing */;
-	else if (sscanf(tochar8(colornam), "#%1x%1x%1x", &r, &g, &b) == 3)
+	/* parse the color name */
+	if (*colornam == '#')
 	{
-	    r *= 17;
-	    g *= 17;
-	    b *= 17;
+		/* Accept X11's "#rrggbb" or "#rgb" notations */
+		if (sscanf(tochar8(colornam), "#%2x%*2x%2x%*2x%2x", &r, &g, &b) == 3)
+			/* do nothing */;
+		else if (sscanf(tochar8(colornam), "#%2x%2x%2x", &r, &g, &b) == 3)
+			/* do nothing */;
+		else if (sscanf(tochar8(colornam), "#%1x%1x%1x", &r, &g, &b) == 3)
+		{
+			r *= 17;
+			g *= 17;
+			b *= 17;
+		}
+		else
+		{
+			msg(MSG_ERROR, "[S]bad color notation $1", colornam);
+			return ElvFalse;
+		}
+	}
+	else if (!*colornam)
+	{
+		r = g = b = -1;
 	}
 	else
 	{
-	    msg(MSG_ERROR, "[S]bad color notation $1", colornam);
-	    return ElvFalse;
-	}
-    }
-    else if (!*colornam)
-    {
-	r = g = b = -1;
-    }
-    else
-    {
-	/* Normalize the color name by converting to lowercase and removing
-	 * whitespace.  We can safely modify the colornam[] buffer in-place.
-	 */
-	for (i = j = 0; colornam[i]; i++)
-	    if (!elvspace(colornam[i]))
-	    colornam[j++] = elvtolower(colornam[i]);
-	colornam[j] = '\0';
+		/* Normalize the color name by converting to lowercase and removing
+		 * whitespace.  We can safely modify the colornam[] buffer in-place.
+		 */
+		for (i = j = 0; colornam[i]; i++)
+			if (!elvspace(colornam[i]))
+				colornam[j++] = elvtolower(colornam[i]);
+		colornam[j] = '\0';
 
-	/* look up the color */
-	for (i = 0;
-	     colortbl[i].name && CHARcmp(toCHAR(colortbl[i].name), colornam);
-	     i++)
-	{
-	}
-	if (colortbl[i].name)
-	{
-	    /* Use the found color */
-	    r = colortbl[i].rgb[0];
-	    g = colortbl[i].rgb[1];
-	    b = colortbl[i].rgb[2];
-	}
-	else /* not found -- try "rgb.txt" */
-	{
-	    /* search for the color in the "rgb.txt" file */
-	    *rgbname = '\0';
-	    rgbfile = iopath(o_elvispath, "rgb.txt", ElvFalse);
-	    if (rgbfile) {
-		fp = fopen(rgbfile, "r");
-		if (fp) {
-		    while (fscanf(fp, "%d %d %d %s", &r, &g, &b, &rgbname) == 4
-			    && CHARcmp(tochar8(rgbname), colornam))
-		    {
-		    }
-		    fclose(fp);
+		/* look up the color */
+		for (i = 0;
+			 colortbl[i].name && CHARcmp(toCHAR(colortbl[i].name), colornam);
+			 i++)
+		{
 		}
-	    }
+		if (colortbl[i].name)
+		{
+			/* Use the found color */
+			r = colortbl[i].rgb[0];
+			g = colortbl[i].rgb[1];
+			b = colortbl[i].rgb[2];
+		}
+		else /* not found -- try "rgb.txt" */
+		{
+			/* search for the color in the "rgb.txt" file */
+			*rgbname = '\0';
+			rgbfile = iopath(o_elvispath, "rgb.txt", ElvFalse);
+			if (rgbfile) {
+				fp = fopen(rgbfile, "r");
+				if (fp) {
+					while (fscanf(fp, "%d %d %d %s", &r, &g, &b, &rgbname) == 4
+					       && CHARcmp(tochar8(rgbname), colornam))
+					{
+					}
+					fclose(fp);
+				}
+			}
 
-	    /* if we didn't find it there, then fail */
-	    if (CHARcmp(tochar8(rgbname), colornam)) {
-		if (isfg) {
-		    memcpy(rgb, colorinfo[COLOR_FONT_NORMAL].da.fg_rgb, 3);
-		    *colorptr = colorinfo[COLOR_FONT_NORMAL].fg;
-		} else {
-		    memcpy(rgb, colorinfo[COLOR_FONT_NORMAL].da.bg_rgb, 3);
-		    *colorptr = colorinfo[COLOR_FONT_NORMAL].bg;
+			/* if we didn't find it there, then fail */
+			if (CHARcmp(tochar8(rgbname), colornam)) {
+				if (isfg) {
+					memcpy(rgb, colorinfo[COLOR_FONT_NORMAL].da.fg_rgb, 3);
+					*colorptr = colorinfo[COLOR_FONT_NORMAL].fg;
+				} else {
+					memcpy(rgb, colorinfo[COLOR_FONT_NORMAL].da.bg_rgb, 3);
+					*colorptr = colorinfo[COLOR_FONT_NORMAL].bg;
+				}
+				msg(MSG_ERROR, "[S]unknown color $1", colornam);
+				return ElvFalse;
+			}
 		}
-		msg(MSG_ERROR, "[S]unknown color $1", colornam);
+	}
+
+#ifdef FEATURE_IMAGE
+	if (imagefile && isfg)
+	{
+		msg(MSG_ERROR, "Can't use images for foreground");
 		return ElvFalse;
-	    }
 	}
-    }
-
-#ifdef FEATURE_IMAGE
-    if (imagefile && isfg)
-    {
-	msg(MSG_ERROR, "Can't use images for foreground");
-	return ElvFalse;
-    }
 #endif
 
-    /* if no image or color, then fail */
-    if (
+	/* if no image or color, then fail */
+	if (
 #ifdef FEATURE_IMAGE
-	!imagefile &&
+		!imagefile &&
 #endif
-		      r < 0)
-    {
-        msg(MSG_ERROR, "missing color name");
-        return ElvFalse;
-    }
-
-#ifdef FEATURE_IMAGE
-    /* if image name was given for "normal" or "idle" font, then load image */
-    if (imagefile && (fontcode==COLOR_FONT_NORMAL || fontcode==COLOR_FONT_IDLE))
-    {
-	/* decide whether to use a tint */
-	if (r >= 0)
-	    average = RGB(r, g, b);
-	else
-	    average = -1;
-
-	/* load the image */
-	newimg = gw_load_xpm(imagefile, average, &average, NULL);
-	if (newimg)
+		  r < 0)
 	{
-	    /* use the average colors */
-	    r = GetRValue(average);
-	    g = GetGValue(average);
-	    b = GetBValue(average);
+		msg(MSG_ERROR, "missing color name");
+		return ElvFalse;
+	}
 
-	    /* if there was an old image, discard it now */
-	    if (fontcode == COLOR_FONT_NORMAL && normalimage)
+#ifdef FEATURE_IMAGE
+	/* if image name was given for "normal" or "idle" font, then load image */
+	if (imagefile && (fontcode==COLOR_FONT_NORMAL || fontcode==COLOR_FONT_IDLE))
+	{
+		/* decide whether to use a tint */
+		if (r >= 0)
+			average = RGB(r, g, b);
+		else
+			average = -1;
+
+		/* load the image */
+		newimg = gw_load_xpm(imagefile, average, &average, NULL);
+		if (newimg)
+		{
+			/* use the average colors */
+			r = GetRValue(average);
+			g = GetGValue(average);
+			b = GetBValue(average);
+
+			/* if there was an old image, discard it now */
+			if (fontcode == COLOR_FONT_NORMAL && normalimage)
+			gw_unload_xpm(normalimage);
+			if (fontcode == COLOR_FONT_IDLE && idleimage)
+			gw_unload_xpm(idleimage);
+
+			/* store the new image */
+			if (fontcode == COLOR_FONT_NORMAL)
+			normalimage = newimg;
+			else
+			idleimage = newimg;
+		}
+		else
+		{
+			return ElvFalse;
+		}
+	}
+	if (!imagefile && fontcode==COLOR_FONT_NORMAL && normalimage && !isfg)
+	{
 		gw_unload_xpm(normalimage);
-	    if (fontcode == COLOR_FONT_IDLE && idleimage)
-		gw_unload_xpm(idleimage);
-
-	    /* store the new image */
-	    if (fontcode == COLOR_FONT_NORMAL)
-		normalimage = newimg;
-	    else
-		idleimage = newimg;
+		normalimage = NULL;
 	}
-	else
+	if (!imagefile && fontcode==COLOR_FONT_IDLE && idleimage && !isfg)
 	{
-	    return ElvFalse;
+		gw_unload_xpm(idleimage);
+		idleimage = NULL;
 	}
-    }
-    if (!imagefile && fontcode==COLOR_FONT_NORMAL && normalimage && !isfg)
-    {
-	gw_unload_xpm(normalimage);
-        normalimage = NULL;
-    }
-    if (!imagefile && fontcode==COLOR_FONT_IDLE && idleimage && !isfg)
-    {
-	gw_unload_xpm(idleimage);
-	idleimage = NULL;
-    }
 #endif
 
-    /* Success!  Store the color and return ElvTrue */
-    *colorptr = RGB(r, g, b);
-    rgb[0] = r;
-    rgb[1] = g;
-    rgb[2] = b;
-    return ElvTrue;
+	/* Success!  Store the color and return ElvTrue */
+	*colorptr = RGB(r, g, b);
+	rgb[0] = r;
+	rgb[1] = g;
+	rgb[2] = b;
+	return ElvTrue;
 }                               
 
 /* --------------------------------------------------------------------
@@ -1329,53 +1329,53 @@ static ELVBOOL gwcolor (int fontcode, Char *colornam, ELVBOOL isfg, long *colorp
 
 void gwsetbg(GUIWIN *gw, long bg)
 {
-    GUI_WINDOW  *gwp = (GUI_WINDOW *)gw;
-    RECT        rect;
-    HDC		hDC;
-    HBRUSH	hBrush;
+	GUI_WINDOW  *gwp = (GUI_WINDOW *)gw;
+	RECT        rect;
+	HDC		hDC;
+	HBRUSH	hBrush;
 
-    /* store the new background color */
-    gwp->bg = (COLORREF)bg;
+	/* store the new background color */
+	gwp->bg = (COLORREF)bg;
 
-    /* get the window's DC */
-    hDC = GetDC (gwp->clientHWnd);
-    SetMapMode (hDC, MM_TEXT);
+	/* get the window's DC */
+	hDC = GetDC (gwp->clientHWnd);
+	SetMapMode (hDC, MM_TEXT);
 
-    /* hide caret */
-    if (gwp->cursor_type != CURSOR_NONE && gwp->clientHWnd == GetFocus ())
-    {
-	HideCaret (gwp->clientHWnd);
-	gwp->cursor_type = CURSOR_NONE;
-    }
+	/* hide caret */
+	if (gwp->cursor_type != CURSOR_NONE && gwp->clientHWnd == GetFocus ())
+	{
+		HideCaret (gwp->clientHWnd);
+		gwp->cursor_type = CURSOR_NONE;
+	}
 
-    /* The portable part of elvis already knows it needs to redraw the text
-     * area, but it doesn't know about blank areas around the outside of the
-     * window.  The simplest way to color those areas is to simply fill the
-     * whole window.
-     */
-    rect.left = 0;
-    rect.top = 0;
-    rect.right = gwp->xsize + gwp->xcsize * 2;
-    rect.bottom = gwp->ysize + gwp->ycsize;
+	/* The portable part of elvis already knows it needs to redraw the text
+	 * area, but it doesn't know about blank areas around the outside of the
+	 * window.  The simplest way to color those areas is to simply fill the
+	 * whole window.
+	 */
+	rect.left = 0;
+	rect.top = 0;
+	rect.right = gwp->xsize + gwp->xcsize * 2;
+	rect.bottom = gwp->ysize + gwp->ycsize;
 #ifdef FEATURE_IMAGE
-    if (normalimage && bg == colorinfo[COLOR_FONT_NORMAL].bg)
-    {
-	gw_erase_rect(hDC, &rect, normalimage, gwp->scrolled);
-    }
-    else if (idleimage && bg == colorinfo[COLOR_FONT_IDLE].bg)
-    {
-	gw_erase_rect(hDC, &rect, idleimage, gwp->scrolled);
-    }
-    else
+	if (normalimage && bg == colorinfo[COLOR_FONT_NORMAL].bg)
+	{
+		gw_erase_rect(hDC, &rect, normalimage, gwp->scrolled);
+	}
+	else if (idleimage && bg == colorinfo[COLOR_FONT_IDLE].bg)
+	{
+		gw_erase_rect(hDC, &rect, idleimage, gwp->scrolled);
+	}
+	else
 #endif
-    {
-	hBrush = CreateSolidBrush(gwp->bg);
-	FillRect(hDC, &rect, hBrush);
-	DeleteObject(hBrush);
-    }
+	{
+		hBrush = CreateSolidBrush(gwp->bg);
+		FillRect(hDC, &rect, hBrush);
+		DeleteObject(hBrush);
+	}
 
-    /* release the window's DC */
-    ReleaseDC(gwp->clientHWnd, hDC);
+	/* release the window's DC */
+	ReleaseDC(gwp->clientHWnd, hDC);
 }
 
 /* --------------------------------------------------------------------
@@ -1386,23 +1386,23 @@ void gwsetbg(GUIWIN *gw, long bg)
 static RESULT gwstop (ELVBOOL alwaysform)
 
 {
-    PROCESS_INFORMATION	    proc;
-    STARTUPINFO	            start;
+	PROCESS_INFORMATION	    proc;
+	STARTUPINFO	            start;
 
-    /* save the buffers, if we're supposed to */
-    eventsuspend ();
+	/* save the buffers, if we're supposed to */
+	eventsuspend ();
 
-    /* start the process */
-    memset (&start, 0, sizeof (start));
-    start.cb = sizeof (start);
-    if (CreateProcess (NULL, o_shell ? o_shell : tochar8 (o_shell), NULL,
-                       NULL, FALSE, CREATE_DEFAULT_ERROR_MODE |
-                       CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP |
-                       NORMAL_PRIORITY_CLASS, NULL, NULL, &start, &proc))
-	    return RESULT_COMPLETE;
+	/* start the process */
+	memset (&start, 0, sizeof (start));
+	start.cb = sizeof (start);
+	if (CreateProcess (NULL, o_shell ? o_shell : tochar8 (o_shell), NULL,
+	                   NULL, FALSE, CREATE_DEFAULT_ERROR_MODE |
+	                   CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP |
+	                   NORMAL_PRIORITY_CLASS, NULL, NULL, &start, &proc))
+		return RESULT_COMPLETE;
 
-    /* dang! */
-    return RESULT_ERROR;
+	/* dang! */
+	return RESULT_ERROR;
 }
 
 /* -------------------------------------------------------------------- */

--- a/guiwin32/gwcmd.c
+++ b/guiwin32/gwcmd.c
@@ -25,10 +25,10 @@ extern char     *gw_new_buffer;
 static void gwcmd_file_new (GUI_WINDOW *gwp)
 
 {
-    BUFFER      pbuf = bufalloc (NULL, 0, ElvFalse);
-    
-    if (pbuf != NULL)
-        eventreplace ((GUIWIN *)gwp, ElvFalse, o_bufname (pbuf));
+	BUFFER      pbuf = bufalloc (NULL, 0, ElvFalse);
+
+	if (pbuf != NULL)
+		eventreplace ((GUIWIN *)gwp, ElvFalse, o_bufname (pbuf));
 }
 
 /* --------------------------------------------------------------------
@@ -39,33 +39,33 @@ static void gwcmd_file_new (GUI_WINDOW *gwp)
 static void gwcmd_file_open (GUI_WINDOW *gwp)
 
 {
-    static char         *filters = "All Files\0*.*\0"
-                                   "Text Files\0*.TXT\0"
-                                   "C Files\0*.c;*.cpp;*.h\0"
-                                   "HTML Files\0*.htm;*.html";
-    OPENFILENAME        ofn;
-    char                cmd[_MAX_PATH + 20];
-    Char		*quoted;
+	static char         *filters = "All Files\0*.*\0"
+	                               "Text Files\0*.TXT\0"
+	                               "C Files\0*.c;*.cpp;*.h\0"
+	                               "HTML Files\0*.htm;*.html";
+	OPENFILENAME        ofn;
+	char                cmd[_MAX_PATH + 20];
+	Char		*quoted;
 
-    strcpy (cmd, ":e ");
-    memset (&ofn, 0, sizeof (ofn));
-    ofn.lStructSize = sizeof (OPENFILENAME);
-    ofn.lpstrFilter = (LPCTSTR)filters;
-    ofn.lpstrFile = &cmd[3];
-    ofn.nMaxFile = _MAX_PATH;
-    ofn.lpstrTitle = "Open...";
+	strcpy (cmd, ":e ");
+	memset (&ofn, 0, sizeof (ofn));
+	ofn.lStructSize = sizeof (OPENFILENAME);
+	ofn.lpstrFilter = (LPCTSTR)filters;
+	ofn.lpstrFile = &cmd[3];
+	ofn.nMaxFile = _MAX_PATH;
+	ofn.lpstrTitle = "Open...";
 #if _MSC_VER > 900
-    ofn.Flags = OFN_LONGNAMES | OFN_NOCHANGEDIR;
+	ofn.Flags = OFN_LONGNAMES | OFN_NOCHANGEDIR;
 #else
-    ofn.Flags = OFN_NOCHANGEDIR;
+	ofn.Flags = OFN_NOCHANGEDIR;
 #endif
 
-    if (GetOpenFileName (&ofn) == TRUE) {
+	if (GetOpenFileName (&ofn) == TRUE) {
 		quoted = addquotes(toCHAR("#% ()$"), toCHAR(&cmd[3]));
 		strcpy(&cmd[3], tochar8(quoted));
 		safefree(quoted);
 		eventex ((GUIWIN *)gwp, cmd, ElvFalse);
-    }
+	}
 }
 
 /* --------------------------------------------------------------------
@@ -76,33 +76,33 @@ static void gwcmd_file_open (GUI_WINDOW *gwp)
 static void gwcmd_file_split (GUI_WINDOW *gwp)
 
 {
-    static char         *filters = "All Files\0*.*\0"
-                                   "Text Files\0*.TXT\0"
-                                   "C Files\0*.c;*.cpp;*.h\0"
-                                   "HTML Files\0*.htm;*.html";
-    OPENFILENAME        ofn;
-    char                cmd[_MAX_PATH + 20];
-    Char		*quoted;
+	static char         *filters = "All Files\0*.*\0"
+	                               "Text Files\0*.TXT\0"
+	                               "C Files\0*.c;*.cpp;*.h\0"
+	                               "HTML Files\0*.htm;*.html";
+	OPENFILENAME        ofn;
+	char                cmd[_MAX_PATH + 20];
+	Char		*quoted;
 
-    strcpy (cmd, ":sp ");
-    memset (&ofn, 0, sizeof (ofn));
-    ofn.lStructSize = sizeof (OPENFILENAME);
-    ofn.lpstrFilter = (LPCTSTR)filters;
-    ofn.lpstrFile = &cmd[4];
-    ofn.nMaxFile = _MAX_PATH;
-    ofn.lpstrTitle = "Split...";
+	strcpy (cmd, ":sp ");
+	memset (&ofn, 0, sizeof (ofn));
+	ofn.lStructSize = sizeof (OPENFILENAME);
+	ofn.lpstrFilter = (LPCTSTR)filters;
+	ofn.lpstrFile = &cmd[4];
+	ofn.nMaxFile = _MAX_PATH;
+	ofn.lpstrTitle = "Split...";
 #if _MSC_VER > 900
-    ofn.Flags = OFN_LONGNAMES | OFN_NOCHANGEDIR;
+	ofn.Flags = OFN_LONGNAMES | OFN_NOCHANGEDIR;
 #else
-    ofn.Flags = OFN_NOCHANGEDIR;
+	ofn.Flags = OFN_NOCHANGEDIR;
 #endif
 
-    if (GetOpenFileName (&ofn) == TRUE) {
+	if (GetOpenFileName (&ofn) == TRUE) {
 		quoted = addquotes(toCHAR("#% ()$"), toCHAR(&cmd[4]));
 		strcpy(&cmd[4], tochar8(quoted));
 		safefree(quoted);
 		eventex ((GUIWIN *)gwp, cmd, ElvFalse);
-    }
+	}
 }
 
 /* --------------------------------------------------------------------
@@ -124,28 +124,28 @@ static void gwcmd_file_save (GUI_WINDOW *gwp)
 static void gwcmd_file_saveas (GUI_WINDOW *gwp)
 
 {
-    OPENFILENAME        ofn;
-    char                cmd[_MAX_PATH + 20];
-    Char		*quoted;
+	OPENFILENAME        ofn;
+	char                cmd[_MAX_PATH + 20];
+	Char		*quoted;
 
-    strcpy (cmd, ":w! ");
-    memset (&ofn, 0, sizeof (ofn));
-    ofn.lStructSize = sizeof (OPENFILENAME);
-    ofn.lpstrFile = &cmd[4];
-    ofn.nMaxFile = _MAX_PATH;
-    ofn.lpstrTitle = "Save As...";
+	strcpy (cmd, ":w! ");
+	memset (&ofn, 0, sizeof (ofn));
+	ofn.lStructSize = sizeof (OPENFILENAME);
+	ofn.lpstrFile = &cmd[4];
+	ofn.nMaxFile = _MAX_PATH;
+	ofn.lpstrTitle = "Save As...";
 #if _MSC_VER > 900
-    ofn.Flags = OFN_LONGNAMES | OFN_NOCHANGEDIR | OFN_OVERWRITEPROMPT;
+	ofn.Flags = OFN_LONGNAMES | OFN_NOCHANGEDIR | OFN_OVERWRITEPROMPT;
 #else
-    ofn.Flags = OFN_NOCHANGEDIR | OFN_OVERWRITEPROMPT;
+	ofn.Flags = OFN_NOCHANGEDIR | OFN_OVERWRITEPROMPT;
 #endif
 
-    if (GetOpenFileName (&ofn) == TRUE) {
+	if (GetOpenFileName (&ofn) == TRUE) {
 		quoted = addquotes(toCHAR("#% ()$"), toCHAR(&cmd[4]));
 		strcpy(&cmd[4], tochar8(quoted));
 		safefree(quoted);
 		eventex ((GUIWIN *)gwp, cmd, ElvFalse);
-    }
+	}
 }
 
 /* --------------------------------------------------------------------
@@ -156,38 +156,38 @@ static void gwcmd_file_saveas (GUI_WINDOW *gwp)
 static void gwcmd_file_cd (GUI_WINDOW *gwp)
 
 {
-    OPENFILENAME        ofn;
-    char                cmd[_MAX_PATH + 5];
-    register int        i;
-    Char		*quoted;
+	OPENFILENAME        ofn;
+	char                cmd[_MAX_PATH + 5];
+	register int        i;
+	Char		*quoted;
 
-    strcpy (cmd, ":cd x");
-    memset (&ofn, 0, sizeof (ofn));
-    ofn.lStructSize = sizeof (OPENFILENAME);
-    ofn.hInstance = hInst;
-    ofn.lpstrFile = &cmd[4];
-    ofn.nMaxFile = _MAX_PATH;
-    ofn.lpstrTitle = "Change Directory...";
+	strcpy (cmd, ":cd x");
+	memset (&ofn, 0, sizeof (ofn));
+	ofn.lStructSize = sizeof (OPENFILENAME);
+	ofn.hInstance = hInst;
+	ofn.lpstrFile = &cmd[4];
+	ofn.nMaxFile = _MAX_PATH;
+	ofn.lpstrTitle = "Change Directory...";
 #if _MSC_VER > 900
-    ofn.Flags = OFN_LONGNAMES | OFN_NOCHANGEDIR | OFN_ENABLETEMPLATE;
+	ofn.Flags = OFN_LONGNAMES | OFN_NOCHANGEDIR | OFN_ENABLETEMPLATE;
 #else
-    ofn.Flags = OFN_NOCHANGEDIR | OFN_ENABLETEMPLATE;
+	ofn.Flags = OFN_NOCHANGEDIR | OFN_ENABLETEMPLATE;
 #endif
-    ofn.lpTemplateName = MAKEINTRESOURCE (IDD_DIR_SELECT);
+	ofn.lpTemplateName = MAKEINTRESOURCE (IDD_DIR_SELECT);
 
-    if (GetOpenFileName (&ofn) == TRUE) {
-	/* remove the last element of the return name -- we only want dir */
-        for (i = strlen (cmd); cmd[i] != '\\'; i--)
-            ;
-        cmd[i] = '\0';
+	if (GetOpenFileName (&ofn) == TRUE) {
+		/* remove the last element of the return name -- we only want dir */
+		for (i = strlen (cmd); cmd[i] != '\\'; i--)
+			;
+		cmd[i] = '\0';
 
-	/* quote the dangerous chars */
-        quoted = addquotes(toCHAR("#% ()$"), toCHAR(&cmd[4]));
-        strcpy(&cmd[4], tochar8(quoted));
-        safefree(quoted);
+		/* quote the dangerous chars */
+		quoted = addquotes(toCHAR("#% ()$"), toCHAR(&cmd[4]));
+		strcpy(&cmd[4], tochar8(quoted));
+		safefree(quoted);
 
-        eventex ((GUIWIN *)gwp, cmd, ElvFalse);
-    }
+		eventex ((GUIWIN *)gwp, cmd, ElvFalse);
+	}
 }
 
 /* --------------------------------------------------------------------
@@ -209,18 +209,18 @@ static void gwcmd_file_print (GUI_WINDOW *gwp)
 static void gwcmd_file_printsetup (GUI_WINDOW *gwp)
 
 {
-    DEVNAMES        *dvnp;
+	DEVNAMES        *dvnp;
 
-    gwpdlg.hDevMode = NULL;
-    gwpdlg.Flags = PD_PRINTSETUP;
+	gwpdlg.hDevMode = NULL;
+	gwpdlg.Flags = PD_PRINTSETUP;
 
-    if (PrintDlg (&gwpdlg)) {
+	if (PrintDlg (&gwpdlg)) {
 		dvnp = GlobalLock (gwpdlg.hDevNames);
 		gw_set_default_printer ((char *)dvnp + dvnp->wDeviceOffset,
 								(char *)dvnp + dvnp->wDriverOffset,
 								(char *)dvnp + dvnp->wOutputOffset);
 		GlobalUnlock (gwpdlg.hDevNames);
-    }
+	}
 }
 
 /* --------------------------------------------------------------------
@@ -232,14 +232,14 @@ static void gwcmd_file_exit (GUI_WINDOW *gwp)
 
 {
 #if 0
-    static unsigned char        chr[] = "\x1B:q\r";
+	static unsigned char        chr[] = "\x1B:q\r";
 
-    eventkeys ((GUIWIN *)gwp, &chr[0], 1);
-    eventkeys ((GUIWIN *)gwp, &chr[1], 1);
-    eventkeys ((GUIWIN *)gwp, &chr[2], 1);
-    eventkeys ((GUIWIN *)gwp, &chr[3], 1);
+	eventkeys ((GUIWIN *)gwp, &chr[0], 1);
+	eventkeys ((GUIWIN *)gwp, &chr[1], 1);
+	eventkeys ((GUIWIN *)gwp, &chr[2], 1);
+	eventkeys ((GUIWIN *)gwp, &chr[3], 1);
 #else
-    eventex ((GUIWIN *)gwp, ":q", ElvFalse);
+	eventex ((GUIWIN *)gwp, ":q", ElvFalse);
 #endif
 }
 
@@ -413,24 +413,24 @@ static void gwcmd_window_pfile (GUI_WINDOW *gwp)
 static void gwcmd_options_font (GUI_WINDOW *gwp)
 
 {
-    CHOOSEFONT      font;
-    LOGFONT         lf;
-    HDC             dc;
-    char            str[80];
+	CHOOSEFONT      font;
+	LOGFONT         lf;
+	HDC             dc;
+	char            str[80];
 
-    memset (&font, 0, sizeof (CHOOSEFONT));
-    font.lStructSize = sizeof (CHOOSEFONT);
-    font.lpLogFont = &lf;
-    font.Flags = CF_INITTOLOGFONTSTRUCT | CF_SCREENFONTS | CF_FIXEDPITCHONLY;
+	memset (&font, 0, sizeof (CHOOSEFONT));
+	font.lStructSize = sizeof (CHOOSEFONT);
+	font.lpLogFont = &lf;
+	font.Flags = CF_INITTOLOGFONTSTRUCT | CF_SCREENFONTS | CF_FIXEDPITCHONLY;
 
-    memset (&lf, 0, sizeof (LOGFONT));
-    opt_parse_font (o_font (gwp), &lf);
+	memset (&lf, 0, sizeof (LOGFONT));
+	opt_parse_font (o_font (gwp), &lf);
 
-    if (ChooseFont (&font)) {
+	if (ChooseFont (&font)) {
 		dc = GetDC (NULL);
 		lf.lfHeight = -MulDiv (lf.lfHeight, 72, GetDeviceCaps (dc, LOGPIXELSY));
 		ReleaseDC (NULL, dc);
-        sprintf (str, ":set font=\"%s*%d\"", lf.lfFaceName, lf.lfHeight);
+		sprintf (str, ":set font=\"%s*%d\"", lf.lfFaceName, lf.lfHeight);
 		eventex ((GUIWIN *)gwp, str, ElvFalse);
 	}
 }
@@ -532,147 +532,147 @@ static void gwcmd_help_options (GUI_WINDOW *gwp)
 LONG gwcmd (GUI_WINDOW *gwp, UINT wParam)
 
 {
-    switch (LOWORD (wParam)) {
-        case IDM_FILE_NEW:
-            gwcmd_file_new (gwp);
-            break;
+	switch (LOWORD (wParam)) {
+		case IDM_FILE_NEW:
+			gwcmd_file_new (gwp);
+			break;
 		case IDM_FILE_OPEN:
-		    gwcmd_file_open (gwp);
-		    break;
+			gwcmd_file_open (gwp);
+			break;
 		case IDM_FILE_SPLIT:
-		    gwcmd_file_split (gwp);
-		    break;
+			gwcmd_file_split (gwp);
+			break;
 		case IDM_FILE_SAVE:
-		    gwcmd_file_save (gwp);
-		    break;
+			gwcmd_file_save (gwp);
+			break;
 		case IDM_FILE_SAVEAS:
-		    gwcmd_file_saveas (gwp);
-		    break;
+			gwcmd_file_saveas (gwp);
+			break;
 		case IDM_FILE_CD:
-		    gwcmd_file_cd (gwp);
-		    break;
+			gwcmd_file_cd (gwp);
+			break;
 		case IDM_FILE_PRINT:
-		    gwcmd_file_print (gwp);
-		    break;
+			gwcmd_file_print (gwp);
+			break;
 		case IDM_FILE_PRINTSETUP:
-		    gwcmd_file_printsetup (gwp);
-		    break;
+			gwcmd_file_printsetup (gwp);
+			break;
 		case IDM_FILE_EXIT:
-		    gwcmd_file_exit (gwp);
-		    break;
+			gwcmd_file_exit (gwp);
+			break;
 		case IDM_EDIT_UNDO:
-		    gwcmd_edit_undo (gwp);
-		    break;
+			gwcmd_edit_undo (gwp);
+			break;
 		case IDM_EDIT_REDO:
-		    gwcmd_edit_redo (gwp);
-		    break;
+			gwcmd_edit_redo (gwp);
+			break;
 		case IDM_EDIT_CUT:
-		    gwcmd_edit_cut (gwp);
-		    break;
+			gwcmd_edit_cut (gwp);
+			break;
 		case IDM_EDIT_COPY:
-		    gwcmd_edit_copy (gwp);
-		    break;
+			gwcmd_edit_copy (gwp);
+			break;
 		case IDM_EDIT_PASTE:
-		    gwcmd_edit_paste (gwp);
-		    break;
+			gwcmd_edit_paste (gwp);
+			break;
 		case IDM_SEARCH_SEARCH:
-		    DialogBox (hInst, MAKEINTRESOURCE (IDD_SEARCH), gwp->frameHWnd,
-		               (DLGPROC)DlgSearch);
-		    break;
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_SEARCH), gwp->frameHWnd,
+			           (DLGPROC)DlgSearch);
+			break;
 		case IDM_SEARCH_AGAIN:
-		    gwcmd_search_again (gwp);
-		    break;
+			gwcmd_search_again (gwp);
+			break;
 		case IDM_SEARCH_REPLACE:
-		    DialogBox (hInst, MAKEINTRESOURCE (IDD_REPLACE), gwp->frameHWnd,
-		               (DLGPROC)DlgReplace);
-		    break;
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_REPLACE), gwp->frameHWnd,
+			           (DLGPROC)DlgReplace);
+			break;
 		case IDM_SEARCH_GOTO:
-		    DialogBox (hInst, MAKEINTRESOURCE (IDD_GOTO), gwp->frameHWnd,
-		               (DLGPROC)DlgGoto);
-		    break;
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_GOTO), gwp->frameHWnd,
+			           (DLGPROC)DlgGoto);
+			break;
 		case IDM_SEARCH_NEXT_ERROR:
-		    gwcmd_search_next_error (gwp);
-		    break;
+			gwcmd_search_next_error (gwp);
+			break;
 		case IDM_WINDOW_NEW:
-		    gwcmd_window_new (gwp);
-		    break;
+			gwcmd_window_new (gwp);
+			break;
 		case IDM_WINDOW_NEXT:
-		    gwcmd_window_next (gwp);
-		    break;
+			gwcmd_window_next (gwp);
+			break;
 		case IDM_WINDOW_PREVIOUS:
-		    gwcmd_window_previous (gwp);
-		    break;
+			gwcmd_window_previous (gwp);
+			break;
 		case IDM_WINDOW_NFILE:
-		    gwcmd_window_nfile (gwp);
-		    break;
+			gwcmd_window_nfile (gwp);
+			break;
 		case IDM_WINDOW_PFILE:
-		    gwcmd_window_pfile (gwp);
-		    break;
+			gwcmd_window_pfile (gwp);
+			break;
 		case IDM_WINDOW_BUFFER:
-		    gwcmd_window_buffer (gwp);
-		    break;
+			gwcmd_window_buffer (gwp);
+			break;
 		case IDM_OPTIONS_FONT:
-		    gwcmd_options_font (gwp);
-		    break;
-        case IDM_OPTIONS_GUI:
-            DialogBox (hInst, MAKEINTRESOURCE (IDD_OPT_GUI), gwp->frameHWnd,
-                       (DLGPROC)DlgOptGui);
-            break;
-        case IDM_OPTIONS_BUFFER:
-            DialogBox (hInst, MAKEINTRESOURCE (IDD_OPT_BUFFER), gwp->frameHWnd,
-                       (DLGPROC)DlgOptBuffer);
-            break;
-        case IDM_OPTIONS_GLOBAL:
-            DialogBox (hInst, MAKEINTRESOURCE (IDD_OPT_GLOBAL), gwp->frameHWnd,
-                       (DLGPROC)DlgOptGlobal);
-            break;
-        case IDM_OPTIONS_WINDOW:
-            DialogBox (hInst, MAKEINTRESOURCE (IDD_OPT_WINDOW), gwp->frameHWnd,
-                       (DLGPROC)DlgOptWindow);
-            break;
-        case IDM_OPTIONS_USER:
-            DialogBox (hInst, MAKEINTRESOURCE (IDD_OPT_USER), gwp->frameHWnd,
-                       (DLGPROC)DlgOptUser);
-            break;
+			gwcmd_options_font (gwp);
+			break;
+		case IDM_OPTIONS_GUI:
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_OPT_GUI), gwp->frameHWnd,
+			           (DLGPROC)DlgOptGui);
+			break;
+		case IDM_OPTIONS_BUFFER:
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_OPT_BUFFER), gwp->frameHWnd,
+			           (DLGPROC)DlgOptBuffer);
+			break;
+		case IDM_OPTIONS_GLOBAL:
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_OPT_GLOBAL), gwp->frameHWnd,
+			           (DLGPROC)DlgOptGlobal);
+			break;
+		case IDM_OPTIONS_WINDOW:
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_OPT_WINDOW), gwp->frameHWnd,
+			           (DLGPROC)DlgOptWindow);
+			break;
+		case IDM_OPTIONS_USER:
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_OPT_USER), gwp->frameHWnd,
+			           (DLGPROC)DlgOptUser);
+			break;
 		case IDM_OPTIONS_SAVE:
-		    gwcmd_options_save (gwp);
-		    break;
+			gwcmd_options_save (gwp);
+			break;
 		case IDM_TOOLS_COMPILE:
-		    gwcmd_tools_compile (gwp);
-		    break;
+			gwcmd_tools_compile (gwp);
+			break;
 		case IDM_TOOLS_MAKE:
-		    gwcmd_tools_make (gwp);
-		    break;
+			gwcmd_tools_make (gwp);
+			break;
 		case IDM_TOOLS_TAGS:
-		    DialogBox (hInst, MAKEINTRESOURCE (IDD_TAGS), gwp->frameHWnd,
-		               (DLGPROC)DlgTags);
-		    break;
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_TAGS), gwp->frameHWnd,
+			           (DLGPROC)DlgTags);
+			break;
 		case IDM_TOOLS_RUN:
-		    DialogBox (hInst, MAKEINTRESOURCE (IDD_RUN), gwp->frameHWnd,
-		               (DLGPROC)DlgRun);
-		    break;
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_RUN), gwp->frameHWnd,
+			           (DLGPROC)DlgRun);
+			break;
 		case IDM_TOOLS_SHELL:
-		    gwcmd_tools_shell (gwp);
-		    break;
+			gwcmd_tools_shell (gwp);
+			break;
 		case IDM_HELP_INDEX:
-		    gwcmd_help_index (gwp);
-		    break;
+			gwcmd_help_index (gwp);
+			break;
 		case IDM_HELP_EX:
-		    gwcmd_help_ex (gwp);
-		    break;
+			gwcmd_help_ex (gwp);
+			break;
 		case IDM_HELP_VI:
-		    gwcmd_help_vi (gwp);
-		    break;
+			gwcmd_help_vi (gwp);
+			break;
 		case IDM_HELP_OPTIONS:
-		    gwcmd_help_options (gwp);
-		    break;
+			gwcmd_help_options (gwp);
+			break;
 		case IDM_HELP_ABOUT:
-		    DialogBox (hInst, MAKEINTRESOURCE (IDD_ABOUT), gwp->frameHWnd,
-		               (DLGPROC)DlgAbout);
-		    break;
-    }
+			DialogBox (hInst, MAKEINTRESOURCE (IDD_ABOUT), gwp->frameHWnd,
+			           (DLGPROC)DlgAbout);
+			break;
+	}
 
-    return 0;
+	return 0;
 }
 
 #endif

--- a/guiwin32/gwcmd.c
+++ b/guiwin32/gwcmd.c
@@ -29,6 +29,8 @@ static void gwcmd_file_new (GUI_WINDOW *gwp)
 
 	if (pbuf != NULL)
 		eventreplace ((GUIWIN *)gwp, ElvFalse, o_bufname (pbuf));
+
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -65,6 +67,7 @@ static void gwcmd_file_open (GUI_WINDOW *gwp)
 		strcpy(&cmd[3], tochar8(quoted));
 		safefree(quoted);
 		eventex ((GUIWIN *)gwp, cmd, ElvFalse);
+		gw_redraw_win (gwp);
 	}
 }
 
@@ -102,6 +105,7 @@ static void gwcmd_file_split (GUI_WINDOW *gwp)
 		strcpy(&cmd[4], tochar8(quoted));
 		safefree(quoted);
 		eventex ((GUIWIN *)gwp, cmd, ElvFalse);
+		gw_redraw_win (gwp);
 	}
 }
 
@@ -252,6 +256,7 @@ static void gwcmd_edit_undo (GUI_WINDOW *gwp)
 
 {
 	eventex ((GUIWIN *)gwp, ":undo", ElvFalse);
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -263,6 +268,7 @@ static void gwcmd_edit_redo (GUI_WINDOW *gwp)
 
 {
 	eventex ((GUIWIN *)gwp, ":redo", ElvFalse);
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -282,6 +288,7 @@ static void gwcmd_edit_cut (GUI_WINDOW *gwp)
 		(void)eventclick ((GUIWIN *)gwp, -1, -1, CLICK_CANCEL);
 	}
 #endif
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -300,6 +307,7 @@ static void gwcmd_edit_copy (GUI_WINDOW *gwp)
 		(void)eventclick ((GUIWIN *)gwp, -1, -1, CLICK_CANCEL);
 	}
 #endif
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -315,6 +323,7 @@ static void gwcmd_edit_paste (GUI_WINDOW *gwp)
 #else
 	(void)eventclick ((GUIWIN *)gwp, -1, -1, CLICK_PASTE);
 #endif
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -326,6 +335,7 @@ static void gwcmd_search_again (GUI_WINDOW *gwp)
 
 {
 	eventex ((GUIWIN *)gwp, "/", ElvFalse);
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -337,6 +347,7 @@ static void gwcmd_search_next_error (GUI_WINDOW *gwp)
 
 {
 	eventex ((GUIWIN *)gwp, ":errlist", ElvFalse);
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -348,6 +359,7 @@ static void gwcmd_window_new (GUI_WINDOW *gwp)
 
 {
 	eventex ((GUIWIN *)gwp, ":split", ElvFalse);
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -359,6 +371,7 @@ static void gwcmd_window_next (GUI_WINDOW *gwp)
 
 {
 	eventex ((GUIWIN *)gwp, ":window ++", ElvFalse);
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -370,6 +383,7 @@ static void gwcmd_window_previous (GUI_WINDOW *gwp)
 
 {
 	eventex ((GUIWIN *)gwp, ":window --", ElvFalse);
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -381,6 +395,7 @@ static void gwcmd_window_nfile (GUI_WINDOW *gwp)
 
 {
 	eventex ((GUIWIN *)gwp, ":next", ElvFalse);
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -392,6 +407,7 @@ static void gwcmd_window_buffer (GUI_WINDOW *gwp)
 
 {
 	eventex ((GUIWIN *)gwp, ":bb", ElvFalse);
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -403,6 +419,7 @@ static void gwcmd_window_pfile (GUI_WINDOW *gwp)
 
 {
 	eventex ((GUIWIN *)gwp, ":prev", ElvFalse);
+	gw_redraw_win (gwp);
 }
 
 /* --------------------------------------------------------------------
@@ -432,6 +449,7 @@ static void gwcmd_options_font (GUI_WINDOW *gwp)
 		ReleaseDC (NULL, dc);
 		sprintf (str, ":set font=\"%s*%d\"", lf.lfFaceName, lf.lfHeight);
 		eventex ((GUIWIN *)gwp, str, ElvFalse);
+		gw_redraw_win (gwp);
 	}
 }
 

--- a/guiwin32/gwmsg.c
+++ b/guiwin32/gwmsg.c
@@ -38,25 +38,25 @@ static int      mouse_selection = MOUSE_SEL_NONE;
 LONG gwframe_WM_GETMINMAXINFO (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    RECT            viewRect;
-    RECT            frameRect;
-    MINMAXINFO      *mmi = (MINMAXINFO *)lParam;
+	RECT            viewRect;
+	RECT            frameRect;
+	MINMAXINFO      *mmi = (MINMAXINFO *)lParam;
 
-    if (gwp == NULL)
-        return 1;
+	if (gwp == NULL)
+		return 1;
 
-    mmi->ptMinTrackSize.x = 30 * gwp->xcsize + gwp->xcsize / 2 + 2;
-    mmi->ptMinTrackSize.y = 2 * gwp->ycsize + 2;
+	mmi->ptMinTrackSize.x = 30 * gwp->xcsize + gwp->xcsize / 2 + 2;
+	mmi->ptMinTrackSize.y = 2 * gwp->ycsize + 2;
 
-    GetWindowRect (gwp->frameHWnd, &frameRect);
-    frameRect.right -= frameRect.left;
-    frameRect.bottom -= frameRect.top;
-    GetClientRect (gwp->clientHWnd, &viewRect);
+	GetWindowRect (gwp->frameHWnd, &frameRect);
+	frameRect.right -= frameRect.left;
+	frameRect.bottom -= frameRect.top;
+	GetClientRect (gwp->clientHWnd, &viewRect);
 
-    mmi->ptMinTrackSize.x += (frameRect.right - viewRect.right);
-    mmi->ptMinTrackSize.y += (frameRect.bottom - viewRect.bottom);
+	mmi->ptMinTrackSize.x += (frameRect.right - viewRect.right);
+	mmi->ptMinTrackSize.y += (frameRect.bottom - viewRect.bottom);
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -67,7 +67,7 @@ LONG gwframe_WM_GETMINMAXINFO (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwframe_WM_INITMENU (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    return 1;
+	return 1;
 }
 
 /* --------------------------------------------------------------------
@@ -78,22 +78,22 @@ LONG gwframe_WM_INITMENU (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwframe_WM_MENUSELECT (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    char        str[80];
-    char        *p;
+	char        str[80];
+	char        *p;
 
-    if (lParam == 0)
-        gw_status_bar_text (gwp, NULL);
-    else {
-        if (LoadString (hInst, LOWORD (wParam), str, sizeof (str)) > 0) {
-            if ((p = strchr (str, '\n')) != NULL)
-                *p = '\0';
-            gw_status_bar_text (gwp, str);
+	if (lParam == 0)
+		gw_status_bar_text (gwp, NULL);
+	else {
+		if (LoadString (hInst, LOWORD (wParam), str, sizeof (str)) > 0) {
+			if ((p = strchr (str, '\n')) != NULL)
+				*p = '\0';
+			gw_status_bar_text (gwp, str);
+		}
+		else
+			gw_status_bar_text (gwp, NULL);
 	}
-	else
-	    gw_status_bar_text (gwp, NULL);
-    }
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -105,10 +105,10 @@ LONG gwframe_WM_MENUSELECT (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwframe_WM_NOTIFY (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    if (gwp->toolbarHWnd != NULL)
-        gw_toolbar_tooltip (gwp, lParam);
+	if (gwp->toolbarHWnd != NULL)
+		gw_toolbar_tooltip (gwp, lParam);
 
-    return 0;
+	return 0;
 }
 #endif
 
@@ -120,12 +120,12 @@ LONG gwframe_WM_NOTIFY (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwframe_WM_PAINT (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    PAINTSTRUCT     ps;
+	PAINTSTRUCT     ps;
 
-    BeginPaint (gwp->frameHWnd, &ps);
-    EndPaint (gwp->frameHWnd, &ps);
+	BeginPaint (gwp->frameHWnd, &ps);
+	EndPaint (gwp->frameHWnd, &ps);
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -136,10 +136,10 @@ LONG gwframe_WM_PAINT (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwframe_WM_SETFOCUS (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    if (gwp->active)
-	SetFocus (gwp->clientHWnd);
+	if (gwp->active)
+		SetFocus (gwp->clientHWnd);
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -150,18 +150,18 @@ LONG gwframe_WM_SETFOCUS (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwframe_WM_SIZE (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    RECT        rect;
+	RECT        rect;
 
-    GetClientRect (gwp->frameHWnd, &rect);
-    rect.top += gw_size_toolbar (gwp, &rect);
-    rect.bottom -= gw_size_status_bar (gwp, &rect, wParam == SIZE_MAXIMIZED);
-    if (wParam != SIZE_MINIMIZED) {
-        SetWindowPos (gwp->clientHWnd, NULL, rect.left, rect.top,
-                      rect.right - rect.left, rect.bottom - rect.top,
-                      SWP_NOZORDER);
-    }
+	GetClientRect (gwp->frameHWnd, &rect);
+	rect.top += gw_size_toolbar (gwp, &rect);
+	rect.bottom -= gw_size_status_bar (gwp, &rect, wParam == SIZE_MAXIMIZED);
+	if (wParam != SIZE_MINIMIZED) {
+		SetWindowPos (gwp->clientHWnd, NULL, rect.left, rect.top,
+		              rect.right - rect.left, rect.bottom - rect.top,
+		              SWP_NOZORDER);
+	}
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -172,18 +172,18 @@ LONG gwframe_WM_SIZE (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_CHAR (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    unsigned char       chr = (unsigned char)wParam;
-    int		        i;
+	unsigned char       chr = (unsigned char)wParam;
+	int		        i;
 
-    /* skip <Shift-Tab> -- it is handled in gwclient_WM_KEYDOWN() */
-    if (chr == '\t' && state_shift)
-    	return 1;
+	/* skip <Shift-Tab> -- it is handled in gwclient_WM_KEYDOWN() */
+	if (chr == '\t' && state_shift)
+		return 1;
 
-    /* otherwise pass the key to elvis */
-    for (i = lParam & 0xFFFF; i > 0; i--)
-	eventkeys((GUIWIN *)gwp, &chr, 1);
+	/* otherwise pass the key to elvis */
+	for (i = lParam & 0xFFFF; i > 0; i--)
+		eventkeys((GUIWIN *)gwp, &chr, 1);
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -194,23 +194,23 @@ LONG gwclient_WM_CHAR (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_DROPFILES (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    char       cmd[_MAX_PATH + 4];
-    char       *quoted;
-    UINT       i;
-    UINT       numfiles;
+	char       cmd[_MAX_PATH + 4];
+	char       *quoted;
+	UINT       i;
+	UINT       numfiles;
 
-    numfiles = DragQueryFile ((HANDLE)wParam, (UINT)-1, NULL, 0);
-    for (i = 0; i < numfiles; i++) {
-        strcpy (cmd, ":e ");
-        DragQueryFile ((HANDLE)wParam, i, &cmd[3], _MAX_PATH);
-        quoted = tochar8(addquotes(toCHAR("#% ()$"), toCHAR(&cmd[3])));
-        strcpy(&cmd[3], quoted);
-        safefree(quoted);
-        eventex ((GUIWIN *)gwp, cmd, ElvFalse);
-    }
-    DragFinish ((HANDLE)wParam);
+	numfiles = DragQueryFile ((HANDLE)wParam, (UINT)-1, NULL, 0);
+	for (i = 0; i < numfiles; i++) {
+		strcpy (cmd, ":e ");
+		DragQueryFile ((HANDLE)wParam, i, &cmd[3], _MAX_PATH);
+		quoted = tochar8(addquotes(toCHAR("#% ()$"), toCHAR(&cmd[3])));
+		strcpy(&cmd[3], quoted);
+		safefree(quoted);
+		eventex ((GUIWIN *)gwp, cmd, ElvFalse);
+	}
+	DragFinish ((HANDLE)wParam);
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -221,33 +221,33 @@ LONG gwclient_WM_DROPFILES (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_ERASEBKGND (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    RECT        rect;
-    HBRUSH      brush, prevbrush;
-    HDC         dc;
+	RECT        rect;
+	HBRUSH      brush, prevbrush;
+	HDC         dc;
 
-    dc = GetDC (gwp->clientHWnd);
-    GetUpdateRect (gwp->clientHWnd, &rect, FALSE);
+	dc = GetDC (gwp->clientHWnd);
+	GetUpdateRect (gwp->clientHWnd, &rect, FALSE);
 #ifdef FEATURE_IMAGE
-    if (normalimage && gwp->bg == (COLORREF)colorinfo[COLOR_FONT_NORMAL].bg)
-    {
-    	gw_erase_rect(dc, &rect, normalimage, gwp->scrolled);
-    }
-    else if (idleimage && gwp->bg == (COLORREF)colorinfo[COLOR_FONT_IDLE].bg)
-    {
-    	gw_erase_rect(dc, &rect, idleimage, gwp->scrolled);
-    }
-    else
+	if (normalimage && gwp->bg == (COLORREF)colorinfo[COLOR_FONT_NORMAL].bg)
+	{
+		gw_erase_rect(dc, &rect, normalimage, gwp->scrolled);
+	}
+	else if (idleimage && gwp->bg == (COLORREF)colorinfo[COLOR_FONT_IDLE].bg)
+	{
+		gw_erase_rect(dc, &rect, idleimage, gwp->scrolled);
+	}
+	else
 #endif
-    {
-	brush = CreateSolidBrush (gwp->bg);
-	prevbrush = SelectObject (dc, brush);
-	FillRect (dc, &rect, brush);
-	prevbrush = SelectObject (dc, prevbrush);
-	DeleteObject (brush);
-    }
-    ReleaseDC (gwp->clientHWnd, dc);
+	{
+		brush = CreateSolidBrush (gwp->bg);
+		prevbrush = SelectObject (dc, brush);
+		FillRect (dc, &rect, brush);
+		prevbrush = SelectObject (dc, prevbrush);
+		DeleteObject (brush);
+	}
+	ReleaseDC (gwp->clientHWnd, dc);
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -258,123 +258,123 @@ LONG gwclient_WM_ERASEBKGND (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_KEYDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    unsigned char       chr[3];
-    int			        i;
+	unsigned char       chr[3];
+	int			        i;
 
-    if (wParam == VK_SHIFT)
-        state_shift = 1;
-    else if (wParam == VK_CONTROL)
-        state_ctrl = 1;
-    else if (wParam == VK_NUMLOCK || wParam == VK_CAPITAL) {
-	gw_upd_status_bar_ind (gwp, GetKeyState (VK_NUMLOCK) & 1,
-				    GetKeyState (VK_CAPITAL) & 1);
-    }
-    else {
-        if (state_ctrl) {
-            switch (wParam) {
-                case VK_LEFT:
-                case VK_RIGHT:
-                case VK_PRIOR:
-                case VK_NEXT:
-                case VK_HOME:
-                case VK_END:
-                case VK_F1:
-                case VK_F2:
-                case VK_F3:
-                case VK_F4:
-                case VK_F5:
-                case VK_F6:
-                case VK_F7:
-                case VK_F8:
-                case VK_F9:
-                case VK_F10:
-                case VK_F11:
-                case VK_F12:
-                    chr[0] = (unsigned char)'\xFF';
-                    chr[1] = 'C';
-                    chr[2] = (unsigned char)wParam;
-		for (i = lParam & 0xFFFF; i > 0; i--)
-		    eventkeys ((GUIWIN *)gwp, chr, 3);
-		return 0;
-            }
-        }
-        else if (state_shift) {
-            switch (wParam) {
-                case VK_UP:
-                case VK_DOWN:
-                    eventclick((GUIWIN *)gwp, 0, 0, CLICK_SSLINE);
-                    chr[0] = (unsigned char)'\xFF';
-                    chr[1] = (unsigned char)wParam;
-                    for (i = lParam & 0xFFFF; i > 0; i--)
-                        eventkeys ((GUIWIN *)gwp, chr, 2);
-                    return 0;
+	if (wParam == VK_SHIFT)
+		state_shift = 1;
+	else if (wParam == VK_CONTROL)
+		state_ctrl = 1;
+	else if (wParam == VK_NUMLOCK || wParam == VK_CAPITAL) {
+		gw_upd_status_bar_ind (gwp, GetKeyState (VK_NUMLOCK) & 1,
+			GetKeyState (VK_CAPITAL) & 1);
+	}
+	else {
+		if (state_ctrl) {
+			switch (wParam) {
+				case VK_LEFT:
+				case VK_RIGHT:
+				case VK_PRIOR:
+				case VK_NEXT:
+				case VK_HOME:
+				case VK_END:
+				case VK_F1:
+				case VK_F2:
+				case VK_F3:
+				case VK_F4:
+				case VK_F5:
+				case VK_F6:
+				case VK_F7:
+				case VK_F8:
+				case VK_F9:
+				case VK_F10:
+				case VK_F11:
+				case VK_F12:
+					chr[0] = (unsigned char)'\xFF';
+					chr[1] = 'C';
+					chr[2] = (unsigned char)wParam;
+					for (i = lParam & 0xFFFF; i > 0; i--)
+						eventkeys ((GUIWIN *)gwp, chr, 3);
+					return 0;
+			}
+		}
+		else if (state_shift) {
+			switch (wParam) {
+				case VK_UP:
+				case VK_DOWN:
+					eventclick((GUIWIN *)gwp, 0, 0, CLICK_SSLINE);
+					chr[0] = (unsigned char)'\xFF';
+					chr[1] = (unsigned char)wParam;
+					for (i = lParam & 0xFFFF; i > 0; i--)
+						eventkeys ((GUIWIN *)gwp, chr, 2);
+					return 0;
 
-                case VK_LEFT:
-                case VK_RIGHT:
-                case VK_HOME:
-                case VK_END:
-                    eventclick((GUIWIN *)gwp, 0, 0, CLICK_SSCHAR);
-                    chr[0] = (unsigned char)'\xFF';
-                    chr[1] = (unsigned char)wParam;
-                    for (i = lParam & 0xFFFF; i > 0; i--)
-                        eventkeys ((GUIWIN *)gwp, chr, 2);
-                    return 0;
+				case VK_LEFT:
+				case VK_RIGHT:
+				case VK_HOME:
+				case VK_END:
+					eventclick((GUIWIN *)gwp, 0, 0, CLICK_SSCHAR);
+					chr[0] = (unsigned char)'\xFF';
+					chr[1] = (unsigned char)wParam;
+					for (i = lParam & 0xFFFF; i > 0; i--)
+						eventkeys ((GUIWIN *)gwp, chr, 2);
+					return 0;
 
-                case VK_F1:
-                case VK_F2:
-                case VK_F3:
-                case VK_F4:
-                case VK_F5:
-                case VK_F6:
-                case VK_F7:
-                case VK_F8:
-                case VK_F9:
-                case VK_F10:
-                case VK_F11:
-                case VK_F12:
-                case VK_TAB:
-                    chr[0] = (unsigned char)'\xFF';
-                    chr[1] = 'S';
-                    chr[2] = (unsigned char)wParam;
-		    for (i = lParam & 0xFFFF; i > 0; i--)
-                        eventkeys ((GUIWIN *)gwp, chr, 3);
-                    return 0;
-            }
-        }
-        else {
-            switch (wParam) {
-                case VK_UP:
-                case VK_DOWN:
-                case VK_LEFT:
-                case VK_RIGHT:
-                case VK_PRIOR:
-                case VK_NEXT:
-                case VK_HOME:
-                case VK_END:
-                case VK_INSERT:
-                case VK_DELETE:
-                case VK_F1:
-                case VK_F2:
-                case VK_F3:
-                case VK_F4:
-                case VK_F5:
-                case VK_F6:
-                case VK_F7:
-                case VK_F8:
-                case VK_F9:
-                case VK_F10:
-                case VK_F11:
-                case VK_F12:
-                    chr[0] = (unsigned char)'\xFF';
-                    chr[1] = (unsigned char)wParam;
-		    for (i = lParam & 0xFFFF; i > 0; i--)
-                        eventkeys ((GUIWIN *)gwp, chr, 2);
-                    return 0;
-            }
-        }
-    }
+				case VK_F1:
+				case VK_F2:
+				case VK_F3:
+				case VK_F4:
+				case VK_F5:
+				case VK_F6:
+				case VK_F7:
+				case VK_F8:
+				case VK_F9:
+				case VK_F10:
+				case VK_F11:
+				case VK_F12:
+				case VK_TAB:
+					chr[0] = (unsigned char)'\xFF';
+					chr[1] = 'S';
+					chr[2] = (unsigned char)wParam;
+					for (i = lParam & 0xFFFF; i > 0; i--)
+						eventkeys ((GUIWIN *)gwp, chr, 3);
+					return 0;
+			}
+		}
+		else {
+			switch (wParam) {
+				case VK_UP:
+				case VK_DOWN:
+				case VK_LEFT:
+				case VK_RIGHT:
+				case VK_PRIOR:
+				case VK_NEXT:
+				case VK_HOME:
+				case VK_END:
+				case VK_INSERT:
+				case VK_DELETE:
+				case VK_F1:
+				case VK_F2:
+				case VK_F3:
+				case VK_F4:
+				case VK_F5:
+				case VK_F6:
+				case VK_F7:
+				case VK_F8:
+				case VK_F9:
+				case VK_F10:
+				case VK_F11:
+				case VK_F12:
+					chr[0] = (unsigned char)'\xFF';
+					chr[1] = (unsigned char)wParam;
+					for (i = lParam & 0xFFFF; i > 0; i--)
+						eventkeys ((GUIWIN *)gwp, chr, 2);
+					return 0;
+			}
+		}
+	}
 
-    return 1;
+	return 1;
 }
 
 /* --------------------------------------------------------------------
@@ -385,15 +385,15 @@ LONG gwclient_WM_KEYDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_KEYUP (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    if (wParam == VK_SHIFT)
-        state_shift = 0;
-    else if (wParam == VK_CONTROL)
-        state_ctrl = 0;
-    else if (wParam == VK_NUMLOCK || wParam == VK_CAPITAL)
-	gw_upd_status_bar_ind (gwp, GetKeyState (VK_NUMLOCK) & 1,
-				    GetKeyState (VK_CAPITAL) & 1);
+	if (wParam == VK_SHIFT)
+		state_shift = 0;
+	else if (wParam == VK_CONTROL)
+		state_ctrl = 0;
+	else if (wParam == VK_NUMLOCK || wParam == VK_CAPITAL)
+		gw_upd_status_bar_ind (gwp, GetKeyState (VK_NUMLOCK) & 1,
+				GetKeyState (VK_CAPITAL) & 1);
 
-    return 1;
+	return 1;
 }
 
 /* --------------------------------------------------------------------
@@ -404,12 +404,12 @@ LONG gwclient_WM_KEYUP (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_KILLFOCUS (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    HideCaret (gwp->clientHWnd);
-    DestroyCaret ();
-    gwp->caret = 0;
-    eventfocus(NULL, ElvTrue);
+	HideCaret (gwp->clientHWnd);
+	DestroyCaret ();
+	gwp->caret = 0;
+	eventfocus(NULL, ElvTrue);
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -420,15 +420,15 @@ LONG gwclient_WM_KILLFOCUS (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_LBUTTONDBLCLK (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    int     row = HIWORD (lParam) / gwp->ycsize;
-    int     col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
+	int     row = HIWORD (lParam) / gwp->ycsize;
+	int     col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
 
-    eventclick ((GUIWIN *)gwp, row, col, CLICK_MOVE);
-    eventclick ((GUIWIN *)gwp, row, col, CLICK_TAG);
-    dblclick = 1;
-    mouse_selection = MOUSE_SEL_NONE;
+	eventclick ((GUIWIN *)gwp, row, col, CLICK_MOVE);
+	eventclick ((GUIWIN *)gwp, row, col, CLICK_TAG);
+	dblclick = 1;
+	mouse_selection = MOUSE_SEL_NONE;
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -439,23 +439,23 @@ LONG gwclient_WM_LBUTTONDBLCLK (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_LBUTTONDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    mouse_down = 1;
+	mouse_down = 1;
 	dblclick = 0;
-    mouse_init_row = HIWORD (lParam) / gwp->ycsize;
-    if (LOWORD (lParam) > (gwp->xcsize / 2))
-        mouse_init_col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
-    else
-	mouse_init_col = 0;
-    mouse_moved = 0;
-    if (LOWORD (lParam) < gwp->xcsize / 2)
-	mouse_selection = MOUSE_SEL_LINE;
-    else if (GetKeyState(VK_MENU))
-	mouse_selection = MOUSE_SEL_RECT;
-    else
-    	mouse_selection = MOUSE_SEL_CHAR;
-    eventclick ((GUIWIN *)gwp, -1, -1, CLICK_CANCEL);
+	mouse_init_row = HIWORD (lParam) / gwp->ycsize;
+	if (LOWORD (lParam) > (gwp->xcsize / 2))
+		mouse_init_col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
+	else
+		mouse_init_col = 0;
+	mouse_moved = 0;
+	if (LOWORD (lParam) < gwp->xcsize / 2)
+		mouse_selection = MOUSE_SEL_LINE;
+	else if (GetKeyState(VK_MENU))
+		mouse_selection = MOUSE_SEL_RECT;
+	else
+		mouse_selection = MOUSE_SEL_CHAR;
+	eventclick ((GUIWIN *)gwp, -1, -1, CLICK_CANCEL);
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -466,15 +466,15 @@ LONG gwclient_WM_LBUTTONDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_LBUTTONUP (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    mouse_down = 0;
-    mouse_moved = 0;
-    if (dblclick == 0)
-	eventclick ((GUIWIN *)gwp, HIWORD (lParam) / gwp->ycsize, 
-                    (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize,
-                    CLICK_MOVE);
-    dblclick = 0;
+	mouse_down = 0;
+	mouse_moved = 0;
+	if (dblclick == 0)
+		eventclick ((GUIWIN *)gwp, HIWORD (lParam) / gwp->ycsize, 
+			(LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize,
+			CLICK_MOVE);
+	dblclick = 0;
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -485,62 +485,62 @@ LONG gwclient_WM_LBUTTONUP (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_MOUSEMOVE (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    int     row;
-    int     col;
+	int     row;
+	int     col;
 
 #if 1
-    //If the mouse is moved from the edge into the window suddenly, then
-    // selectedCursor will be invalid.  Make sure it becomes valid.
-    selectedCursor = GetCursor ();
+	//If the mouse is moved from the edge into the window suddenly, then
+	// selectedCursor will be invalid.  Make sure it becomes valid.
+	selectedCursor = GetCursor ();
 #endif
 
-    row = HIWORD (lParam) / gwp->ycsize;
-    if (LOWORD (lParam) > (gwp->xcsize / 2)) {
-        col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
-        if (selectedCursor != hLeftArrow && !mouse_down) {
-            ShowCursor (FALSE);
-            SetCursor (hLeftArrow);
-            ShowCursor (TRUE);
-            selectedCursor = hLeftArrow;
-         }
-    }
-    else {
-        col = 0;
-        if (selectedCursor != hRightArrow && !mouse_down) {
-            ShowCursor (FALSE);
-            SetCursor (hRightArrow);
-            ShowCursor (TRUE);
-            selectedCursor = hRightArrow;
-        }
-    }
+	row = HIWORD (lParam) / gwp->ycsize;
+	if (LOWORD (lParam) > (gwp->xcsize / 2)) {
+		col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
+		if (selectedCursor != hLeftArrow && !mouse_down) {
+			ShowCursor (FALSE);
+			SetCursor (hLeftArrow);
+			ShowCursor (TRUE);
+			selectedCursor = hLeftArrow;
+		}
+	}
+	else {
+		col = 0;
+		if (selectedCursor != hRightArrow && !mouse_down) {
+			ShowCursor (FALSE);
+			SetCursor (hRightArrow);
+			ShowCursor (TRUE);
+			selectedCursor = hRightArrow;
+		}
+	}
 
-    if (!mouse_down)
-        return 0;
+	if (!mouse_down)
+		return 0;
 
-    if (row == mouse_init_row && col == mouse_init_col &&
-        mouse_selection != MOUSE_SEL_LINE)
-        return 0;
+	if (row == mouse_init_row && col == mouse_init_col &&
+		mouse_selection != MOUSE_SEL_LINE)
+		return 0;
 
-    if (mouse_moved) {
-        eventclick ((GUIWIN *)gwp, row, col, CLICK_MOVE);
-    }
-    else if (mouse_selection == MOUSE_SEL_LINE) {
-        eventclick ((GUIWIN *)gwp, mouse_init_row, mouse_init_col,
-                    CLICK_SELLINE);
-        mouse_moved = 1;
-    }
-    else if (mouse_selection == MOUSE_SEL_CHAR) {
-        eventclick ((GUIWIN *)gwp, mouse_init_row, mouse_init_col,
-                    CLICK_SELCHAR);
-        mouse_moved = 1;
-    }
-    else if (mouse_selection == MOUSE_SEL_RECT) {
-        eventclick ((GUIWIN *)gwp, mouse_init_row, mouse_init_col,
-                    CLICK_SELRECT);
-        mouse_moved = 1;
-    }
+	if (mouse_moved) {
+		eventclick ((GUIWIN *)gwp, row, col, CLICK_MOVE);
+	}
+	else if (mouse_selection == MOUSE_SEL_LINE) {
+		eventclick ((GUIWIN *)gwp, mouse_init_row, mouse_init_col,
+		            CLICK_SELLINE);
+		mouse_moved = 1;
+	}
+	else if (mouse_selection == MOUSE_SEL_CHAR) {
+		eventclick ((GUIWIN *)gwp, mouse_init_row, mouse_init_col,
+		            CLICK_SELCHAR);
+		mouse_moved = 1;
+	}
+	else if (mouse_selection == MOUSE_SEL_RECT) {
+		eventclick ((GUIWIN *)gwp, mouse_init_row, mouse_init_col,
+		            CLICK_SELRECT);
+		mouse_moved = 1;
+	}
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -553,16 +553,16 @@ LONG gwclient_WM_MOUSEMOVE (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_MOUSEWHEEL (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    short        delta = HIWORD (wParam);
+	short        delta = HIWORD (wParam);
+	
+	delta = (delta / WHEEL_DELTA) * 4;
+	if (delta > 0)
+		eventscroll ((GUIWIN *)gwp, SCROLL_BACKLN, delta, 0L);
+	else
+		eventscroll ((GUIWIN *)gwp, SCROLL_FWDLN, -delta, 0L);
+	gw_redraw_win (gwp);
 
-    delta = (delta / WHEEL_DELTA) * 4;
-    if (delta > 0)
-        eventscroll ((GUIWIN *)gwp, SCROLL_BACKLN, delta, 0L);
-    else
-        eventscroll ((GUIWIN *)gwp, SCROLL_FWDLN, -delta, 0L);
-    gw_redraw_win (gwp);
-    
-    return 0;
+	return 0;
 }
 
 #endif
@@ -575,42 +575,42 @@ LONG gwclient_WM_MOUSEWHEEL (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_PAINT (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    PAINTSTRUCT ps;
-    HBRUSH      brush, prevbrush;
-    int         left;
-    int         top;
+	PAINTSTRUCT ps;
+	HBRUSH      brush, prevbrush;
+	int         left;
+	int         top;
 
-    BeginPaint (gwp->clientHWnd, &ps);
+	BeginPaint (gwp->clientHWnd, &ps);
 #ifdef FEATURE_IMAGE
-    if (normalimage && gwp->bg == (COLORREF)colorinfo[COLOR_FONT_NORMAL].bg)
-    {
-    	gw_erase_rect(ps.hdc, &ps.rcPaint, normalimage, gwp->scrolled);
-    }
-    else if (idleimage && gwp->bg == (COLORREF)colorinfo[COLOR_FONT_IDLE].bg)
-    {
-    	gw_erase_rect(ps.hdc, &ps.rcPaint, idleimage, gwp->scrolled);
-    }
-    else
+	if (normalimage && gwp->bg == (COLORREF)colorinfo[COLOR_FONT_NORMAL].bg)
+	{
+		gw_erase_rect(ps.hdc, &ps.rcPaint, normalimage, gwp->scrolled);
+	}
+	else if (idleimage && gwp->bg == (COLORREF)colorinfo[COLOR_FONT_IDLE].bg)
+	{
+		gw_erase_rect(ps.hdc, &ps.rcPaint, idleimage, gwp->scrolled);
+	}
+	else
 #endif
-    {
-	brush = CreateSolidBrush (gwp->bg);
-	FillRect (ps.hdc, &ps.rcPaint, brush);
-	DeleteObject (brush);
-    }
-    if (gwp->active) {
-        SetMapMode (ps.hdc, MM_TEXT);
-        if ((left = ps.rcPaint.left - gwp->xcsize / 2) < 0)
-            left = 0;
-	left = left / gwp->xcsize;
-        top = ps.rcPaint.top / gwp->ycsize;
-        if (left < gwp->numcols && top < gwp->numrows )
-            eventexpose ((GUIWIN *)gwp, top, left,
-                         (ps.rcPaint.bottom + gwp->ycsize) / gwp->ycsize,
-                         (ps.rcPaint.right + gwp->xcsize) / gwp->xcsize);
-    }
-    EndPaint (gwp->clientHWnd, &ps);
+	{
+		brush = CreateSolidBrush (gwp->bg);
+		FillRect (ps.hdc, &ps.rcPaint, brush);
+		DeleteObject (brush);
+	}
+	if (gwp->active) {
+		SetMapMode (ps.hdc, MM_TEXT);
+		if ((left = ps.rcPaint.left - gwp->xcsize / 2) < 0)
+			left = 0;
+		left = left / gwp->xcsize;
+		top = ps.rcPaint.top / gwp->ycsize;
+		if (left < gwp->numcols && top < gwp->numrows )
+			eventexpose ((GUIWIN *)gwp, top, left,
+						 (ps.rcPaint.bottom + gwp->ycsize) / gwp->ycsize,
+						 (ps.rcPaint.right + gwp->xcsize) / gwp->xcsize);
+	}
+	EndPaint (gwp->clientHWnd, &ps);
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -621,15 +621,15 @@ LONG gwclient_WM_PAINT (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_RBUTTONDBLCLK (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    int     row = HIWORD (lParam) / gwp->ycsize;
-    int     col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
+	int     row = HIWORD (lParam) / gwp->ycsize;
+	int     col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
 
-    eventclick ((GUIWIN *)gwp, row, col, CLICK_MOVE);
-    eventclick ((GUIWIN *)gwp, row, col, CLICK_UNTAG);
+	eventclick ((GUIWIN *)gwp, row, col, CLICK_MOVE);
+	eventclick ((GUIWIN *)gwp, row, col, CLICK_UNTAG);
 	dblclick = 1;
 	mouse_selection = MOUSE_SEL_NONE;
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -640,21 +640,21 @@ LONG gwclient_WM_RBUTTONDBLCLK (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_RBUTTONDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    WINDOW      pwin = winofgw ((GUIWIN *)gwp);
+	WINDOW      pwin = winofgw ((GUIWIN *)gwp);
 
 	mouse_down = 1;
 	if (pwin->seltop == NULL) {
 		mouse_moved = 0;
 		mouse_selection = MOUSE_SEL_RECT;
-        mouse_init_row = HIWORD (lParam) / gwp->ycsize;
-        if (LOWORD (lParam) > (gwp->xcsize / 2))
-            mouse_init_col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
-        else
-            mouse_init_col = 0;
-    }
+		mouse_init_row = HIWORD (lParam) / gwp->ycsize;
+		if (LOWORD (lParam) > (gwp->xcsize / 2))
+			mouse_init_col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
+		else
+			mouse_init_col = 0;
+	}
 	dblclick = 0;
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -665,24 +665,24 @@ LONG gwclient_WM_RBUTTONDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_RBUTTONUP (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    WINDOW      pwin = winofgw ((GUIWIN *)gwp);
-    int         row = HIWORD (lParam) / gwp->ycsize;
-    int         col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
+	WINDOW      pwin = winofgw ((GUIWIN *)gwp);
+	int         row = HIWORD (lParam) / gwp->ycsize;
+	int         col = (LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize;
     
 	mouse_down = 0;
 	if (dblclick == 0) {
-	    if (pwin->seltop == NULL) {
-	        eventclick ((GUIWIN *)gwp, -1, -1, CLICK_CANCEL);
+		if (pwin->seltop == NULL) {
+			eventclick ((GUIWIN *)gwp, -1, -1, CLICK_CANCEL);
 			mouse_moved = 0;
 			mouse_selection = MOUSE_SEL_NONE;
 			mouse_init_row = 0;
 			mouse_init_col = 0;
-	    }
+		}
 		eventclick ((GUIWIN *)gwp, row, col, CLICK_MOVE);
 	}
 	dblclick = 0;
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -693,26 +693,26 @@ LONG gwclient_WM_RBUTTONUP (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_SETFOCUS (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    dblclick = 0;
-    state_shift = GetKeyState (VK_SHIFT) < 0;
-    state_ctrl = GetKeyState (VK_CONTROL) < 0;
+	dblclick = 0;
+	state_shift = GetKeyState (VK_SHIFT) < 0;
+	state_ctrl = GetKeyState (VK_CONTROL) < 0;
 
-    if (gwp->active) {
-	gw_upd_status_bar_ind (gwp, GetKeyState (VK_NUMLOCK) & 1,
-				   GetKeyState (VK_CAPITAL) & 1);
-        gwp->cursor_type = eventfocus ((GUIWIN *)gwp, ElvTrue);
-    }
+	if (gwp->active) {
+		gw_upd_status_bar_ind (gwp, GetKeyState (VK_NUMLOCK) & 1,
+			   GetKeyState (VK_CAPITAL) & 1);
+		gwp->cursor_type = eventfocus ((GUIWIN *)gwp, ElvTrue);
+	}
 
-    if (gwp->caret) {
-	HideCaret (gwp->clientHWnd);
-	DestroyCaret ();
-    }
-    gw_set_cursor(gwp, TRUE);
-    ShowCaret (gwp->clientHWnd);
+	if (gwp->caret) {
+		HideCaret (gwp->clientHWnd);
+		DestroyCaret ();
+	}
+	gw_set_cursor(gwp, TRUE);
+	ShowCaret (gwp->clientHWnd);
 
-    gwp->caret = 1;
+	gwp->caret = 1;
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -723,23 +723,23 @@ LONG gwclient_WM_SETFOCUS (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_SIZE (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    int     oldrows;
-    int     oldcols;
+	int     oldrows;
+	int     oldcols;
 
-    if (gwp == NULL)
-	return 1;
+	if (gwp == NULL)
+		return 1;
 
-    if (gwp->active) {
-	oldrows = gwp->numrows;
-	oldcols = gwp->numcols;
-	gw_get_win_size (gwp);
-	if (oldrows != gwp->numrows || oldcols != gwp->numcols) {
-	    eventresize ((GUIWIN *)gwp, gwp->numrows, gwp->numcols);
-	    gw_redraw_win (gwp);
-	    }
-    }
+	if (gwp->active) {
+		oldrows = gwp->numrows;
+		oldcols = gwp->numcols;
+		gw_get_win_size (gwp);
+		if (oldrows != gwp->numrows || oldcols != gwp->numcols) {
+			eventresize ((GUIWIN *)gwp, gwp->numrows, gwp->numcols);
+			gw_redraw_win (gwp);
+		}
+	}
 
-    return 0;
+	return 0;
 }
 
 /* --------------------------------------------------------------------
@@ -750,31 +750,31 @@ LONG gwclient_WM_SIZE (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_SYSKEYDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    unsigned char       chr[3];
-    int                 i;
+	unsigned char       chr[3];
+	int                 i;
 
-    switch (wParam) {
-        case VK_F1:
-        case VK_F2:
-        case VK_F3:
-        case VK_F4:
-        case VK_F5:
-        case VK_F6:
-        case VK_F7:
-        case VK_F8:
-        case VK_F9:
-        case VK_F10:
-        case VK_F11:
-        case VK_F12:
-            chr[0] = (unsigned char)'\xFF';
-            chr[1] = 'A';
-            chr[2] = (unsigned char)wParam;
-	    for (i = lParam & 0xFFFF; i > 0; i--)
-		eventkeys ((GUIWIN *)gwp, chr, 3);
-            return 0;
-    }
+	switch (wParam) {
+		case VK_F1:
+		case VK_F2:
+		case VK_F3:
+		case VK_F4:
+		case VK_F5:
+		case VK_F6:
+		case VK_F7:
+		case VK_F8:
+		case VK_F9:
+		case VK_F10:
+		case VK_F11:
+		case VK_F12:
+			chr[0] = (unsigned char)'\xFF';
+			chr[1] = 'A';
+			chr[2] = (unsigned char)wParam;
+			for (i = lParam & 0xFFFF; i > 0; i--)
+				eventkeys ((GUIWIN *)gwp, chr, 3);
+			return 0;
+	}
 
-    return 1;
+	return 1;
 }
 
 /* --------------------------------------------------------------------
@@ -785,32 +785,32 @@ LONG gwclient_WM_SYSKEYDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 LONG gwclient_WM_VSCROLL (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 {
-    long    nPos = HIWORD (wParam);
-
-    switch (LOWORD (wParam)) {
-        case SB_LINEDOWN:
-            eventscroll ((GUIWIN *)gwp, SCROLL_FWDLN, 1L, 0L);
-            break;
-        case SB_LINEUP:
-            eventscroll ((GUIWIN *)gwp, SCROLL_BACKLN, 1L, 0L);
-            break;
-        case SB_PAGEDOWN:
-            eventscroll ((GUIWIN *)gwp, SCROLL_FWDSCR, 1L, 0L);
-            break;
-        case SB_PAGEUP:
-            eventscroll ((GUIWIN *)gwp, SCROLL_BACKSCR, 1L, 0L);
-            break;
-        case SB_THUMBTRACK:
+	long    nPos = HIWORD (wParam);
+	
+	switch (LOWORD (wParam)) {
+		case SB_LINEDOWN:
+			eventscroll ((GUIWIN *)gwp, SCROLL_FWDLN, 1L, 0L);
+			break;
+		case SB_LINEUP:
+			eventscroll ((GUIWIN *)gwp, SCROLL_BACKLN, 1L, 0L);
+			break;
+		case SB_PAGEDOWN:
+			eventscroll ((GUIWIN *)gwp, SCROLL_FWDSCR, 1L, 0L);
+			break;
+		case SB_PAGEUP:
+			eventscroll ((GUIWIN *)gwp, SCROLL_BACKSCR, 1L, 0L);
+			break;
+		case SB_THUMBTRACK:
 #if 0
-            if (nPos == 0)
-                nPos = 1;
+			if (nPos == 0)
+				nPos = 1;
 #endif
-            eventscroll ((GUIWIN *)gwp, SCROLL_PERCENT, nPos, gwp->scrollsize);
-            break; 
-    }
-    gw_redraw_win (gwp);
-
-    return 0;
+			eventscroll ((GUIWIN *)gwp, SCROLL_PERCENT, nPos, gwp->scrollsize);
+			break; 
+	}
+	gw_redraw_win (gwp);
+	
+	return 0;
 }
 
 #endif

--- a/guiwin32/gwmsg.c
+++ b/guiwin32/gwmsg.c
@@ -183,6 +183,8 @@ LONG gwclient_WM_CHAR (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 	for (i = lParam & 0xFFFF; i > 0; i--)
 		eventkeys((GUIWIN *)gwp, &chr, 1);
 
+	gw_redraw_win (gwp);
+
 	return 0;
 }
 
@@ -209,6 +211,8 @@ LONG gwclient_WM_DROPFILES (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 		eventex ((GUIWIN *)gwp, cmd, ElvFalse);
 	}
 	DragFinish ((HANDLE)wParam);
+
+	gw_redraw_win (gwp);
 
 	return 0;
 }
@@ -295,6 +299,7 @@ LONG gwclient_WM_KEYDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 					chr[2] = (unsigned char)wParam;
 					for (i = lParam & 0xFFFF; i > 0; i--)
 						eventkeys ((GUIWIN *)gwp, chr, 3);
+					gw_redraw_win (gwp);
 					return 0;
 			}
 		}
@@ -307,6 +312,7 @@ LONG gwclient_WM_KEYDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 					chr[1] = (unsigned char)wParam;
 					for (i = lParam & 0xFFFF; i > 0; i--)
 						eventkeys ((GUIWIN *)gwp, chr, 2);
+					gw_redraw_win (gwp);
 					return 0;
 
 				case VK_LEFT:
@@ -318,6 +324,7 @@ LONG gwclient_WM_KEYDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 					chr[1] = (unsigned char)wParam;
 					for (i = lParam & 0xFFFF; i > 0; i--)
 						eventkeys ((GUIWIN *)gwp, chr, 2);
+					gw_redraw_win (gwp);
 					return 0;
 
 				case VK_F1:
@@ -338,6 +345,7 @@ LONG gwclient_WM_KEYDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 					chr[2] = (unsigned char)wParam;
 					for (i = lParam & 0xFFFF; i > 0; i--)
 						eventkeys ((GUIWIN *)gwp, chr, 3);
+					gw_redraw_win (gwp);
 					return 0;
 			}
 		}
@@ -369,6 +377,7 @@ LONG gwclient_WM_KEYDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 					chr[1] = (unsigned char)wParam;
 					for (i = lParam & 0xFFFF; i > 0; i--)
 						eventkeys ((GUIWIN *)gwp, chr, 2);
+					gw_redraw_win (gwp);
 					return 0;
 			}
 		}
@@ -408,6 +417,7 @@ LONG gwclient_WM_KILLFOCUS (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 	DestroyCaret ();
 	gwp->caret = 0;
 	eventfocus(NULL, ElvTrue);
+	gw_redraw_win (gwp);
 
 	return 0;
 }
@@ -427,6 +437,7 @@ LONG gwclient_WM_LBUTTONDBLCLK (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 	eventclick ((GUIWIN *)gwp, row, col, CLICK_TAG);
 	dblclick = 1;
 	mouse_selection = MOUSE_SEL_NONE;
+	gw_redraw_win (gwp);
 
 	return 0;
 }
@@ -454,6 +465,7 @@ LONG gwclient_WM_LBUTTONDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 	else
 		mouse_selection = MOUSE_SEL_CHAR;
 	eventclick ((GUIWIN *)gwp, -1, -1, CLICK_CANCEL);
+	gw_redraw_win (gwp);
 
 	return 0;
 }
@@ -469,9 +481,12 @@ LONG gwclient_WM_LBUTTONUP (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 	mouse_down = 0;
 	mouse_moved = 0;
 	if (dblclick == 0)
+	{
 		eventclick ((GUIWIN *)gwp, HIWORD (lParam) / gwp->ycsize, 
 			(LOWORD (lParam) - gwp->xcsize / 2) / gwp->xcsize,
 			CLICK_MOVE);
+		gw_redraw_win (gwp);
+	}
 	dblclick = 0;
 
 	return 0;
@@ -523,21 +538,25 @@ LONG gwclient_WM_MOUSEMOVE (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 
 	if (mouse_moved) {
 		eventclick ((GUIWIN *)gwp, row, col, CLICK_MOVE);
+		gw_redraw_win (gwp);
 	}
 	else if (mouse_selection == MOUSE_SEL_LINE) {
 		eventclick ((GUIWIN *)gwp, mouse_init_row, mouse_init_col,
 		            CLICK_SELLINE);
 		mouse_moved = 1;
+		gw_redraw_win (gwp);
 	}
 	else if (mouse_selection == MOUSE_SEL_CHAR) {
 		eventclick ((GUIWIN *)gwp, mouse_init_row, mouse_init_col,
 		            CLICK_SELCHAR);
 		mouse_moved = 1;
+		gw_redraw_win (gwp);
 	}
 	else if (mouse_selection == MOUSE_SEL_RECT) {
 		eventclick ((GUIWIN *)gwp, mouse_init_row, mouse_init_col,
 		            CLICK_SELRECT);
 		mouse_moved = 1;
+		gw_redraw_win (gwp);
 	}
 
 	return 0;
@@ -628,6 +647,7 @@ LONG gwclient_WM_RBUTTONDBLCLK (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 	eventclick ((GUIWIN *)gwp, row, col, CLICK_UNTAG);
 	dblclick = 1;
 	mouse_selection = MOUSE_SEL_NONE;
+	gw_redraw_win (gwp);
 
 	return 0;
 }
@@ -653,6 +673,7 @@ LONG gwclient_WM_RBUTTONDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 			mouse_init_col = 0;
 	}
 	dblclick = 0;
+	gw_redraw_win (gwp);
 
 	return 0;
 }
@@ -681,6 +702,7 @@ LONG gwclient_WM_RBUTTONUP (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 		eventclick ((GUIWIN *)gwp, row, col, CLICK_MOVE);
 	}
 	dblclick = 0;
+	gw_redraw_win (gwp);
 
 	return 0;
 }
@@ -711,6 +733,7 @@ LONG gwclient_WM_SETFOCUS (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 	ShowCaret (gwp->clientHWnd);
 
 	gwp->caret = 1;
+	gw_redraw_win (gwp);
 
 	return 0;
 }
@@ -771,6 +794,7 @@ LONG gwclient_WM_SYSKEYDOWN (GUI_WINDOW *gwp, UINT wParam, LONG lParam)
 			chr[2] = (unsigned char)wParam;
 			for (i = lParam & 0xFFFF; i > 0; i--)
 				eventkeys ((GUIWIN *)gwp, chr, 3);
+			gw_redraw_win (gwp);
 			return 0;
 	}
 


### PR DESCRIPTION
In the current code, the Win32 GUI version redraws after each window message.  Window messages are sent to the application for all kinds of reasons, and the majority of these messages are ignored.  Most notably, messages like WM_MOUSEMOVE are generally not reasons to redraw but can be sent in quick succession, resulting in a disconcerting flashing effect.

This change moves redraw after each operation that might change the buffer.  I've tried to be conservative here in the sense of redrawing if there's any doubt that a redraw is needed, but the most likely bugs introduced by this change is a failure to redraw.

Per previous conversation, this splits the whitespace changes from the functional changes.  `git diff -w` is useful for verifying that the whitespace changes aren't changing anything they shouldn't, or to view the functional effect of both.