### PR TITLE
Include manifest for themed controls on XP and above

### DIFF
--- a/guiwin32/WinElvis.rc
+++ b/guiwin32/WinElvis.rc
@@ -24,6 +24,22 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 
 /////////////////////////////////////////////////////////////////////////////
 //
+// Manifest
+//
+
+#ifndef CREATEPROCESS_MANIFEST_RESOURCE_ID
+#define CREATEPROCESS_MANIFEST_RESOURCE_ID 1
+#endif
+
+#ifndef RT_MANIFEST
+#define RT_MANIFEST 24
+#endif
+
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "WinElvis.manifest"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
 // Menu
 //
 

--- a/guiwin32/winelvis.manifest
+++ b/guiwin32/winelvis.manifest
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+<assemblyIdentity 
+    version="1.0.0.0" 
+    name="WinElvis"
+    type="win32" 
+/> 
+<description>WinElvis</description> 
+<dependency> 
+    <dependentAssembly> 
+        <assemblyIdentity 
+            type="win32" 
+            name="Microsoft.Windows.Common-Controls" 
+            version="6.0.0.0" 
+            processorArchitecture="*"
+            publicKeyToken="6595b64144ccf1df" 
+            language="*" 
+        /> 
+    </dependentAssembly> 
+</dependency> 
+</assembly>


### PR DESCRIPTION
Win32 in general achieves compatibility with a lot of "opt-in" changes so that existing code gets existing behavior, and new code can opt-in to new behavior.  This change implements one such opt-in, which is to indicate support for themed controls added in Windows XP.  Without this, the controls are in a Windows 2000 compatibility mode, with no color/animation.  This opt-in is described via an application manifest, which is a chunk of XML text that's linked into an executable and parsed by the program loader.  Because Windows 2000 and earlier do not have this logic, the program works on those versions in the same way it did before.

This is the current Windows 2000 compatibility mode behavior on Windows 8:
![nomanifest](https://user-images.githubusercontent.com/17101641/121922656-051d7a00-ccef-11eb-8ee0-8b5a15d8768b.gif)

This is the behavior when opted into themes on Windows 8:
![manifest](https://user-images.githubusercontent.com/17101641/121922761-1a92a400-ccef-11eb-92aa-94f8a9e90686.gif)

