### PR TITLE
More Win32 build fixes

### DIFF
--- a/makwin32.bat
+++ b/makwin32.bat
@@ -41,7 +41,6 @@ goto Done
 :Clean_NT
 for %%i in (WinRel WinDebug GuiRel GuiDebug) do if exist %%i rd /s/q %%i
 for %%i in (WinElvis.exe WinTags.exe ctags.exe elvis.exe ex.exe fmt.exe ls.exe ref.exe vi.exe view.exe) do if exist %%i erase %%i
-if exist *.pch erase *.pch
 if exist *.pdb erase *.pdb
 if exist *.ilk erase *.ilk
 

--- a/oswin32/elvis.mak
+++ b/oswin32/elvis.mak
@@ -141,11 +141,10 @@ BSC32=bscmake.exe
 BSC32_FLAGS=/nologo /o"$(OUTDIR)/elvis.bsc" 
 BSC32_SBRS=
 LINK32=link.exe
-# ADD BASE LINK32 kernel32.lib wsock32.lib user32.lib /nologo /subsystem:console /machine:I386
-# ADD LINK32 wsock32.lib kernel32.lib user32.lib /nologo /subsystem:console /machine:I386
+# ADD BASE LINK32 kernel32.lib wsock32.lib user32.lib /nologo /subsystem:console
+# ADD LINK32 wsock32.lib kernel32.lib user32.lib /nologo /subsystem:console
 LINK32_FLAGS=wsock32.lib kernel32.lib user32.lib /nologo /subsystem:console\
- /incremental:no /pdb:"$(OUTDIR)/elvis.pdb" /machine:I386\
- /out:"$(OUTDIR)/elvis.exe"
+ /incremental:no /pdb:"$(OUTDIR)/elvis.pdb" /out:"$(OUTDIR)/elvis.exe"
 LINK32_OBJS= \
 	"$(INTDIR)/vi.obj" \
 	"$(INTDIR)/display.obj" \
@@ -332,11 +331,10 @@ BSC32=bscmake.exe
 BSC32_FLAGS=/nologo /o"$(OUTDIR)/elvis.bsc" 
 BSC32_SBRS=
 LINK32=link.exe
-# ADD BASE LINK32 kernel32.lib wsock32.lib user32.lib /nologo /subsystem:console /debug /machine:I386
-# ADD LINK32 wsock32.lib kernel32.lib user32.lib /nologo /subsystem:console /debug /machine:I386
+# ADD BASE LINK32 kernel32.lib wsock32.lib user32.lib /nologo /subsystem:console /debug
+# ADD LINK32 wsock32.lib kernel32.lib user32.lib /nologo /subsystem:console /debug
 LINK32_FLAGS=wsock32.lib kernel32.lib user32.lib /nologo /subsystem:console\
- /incremental:yes /pdb:"$(OUTDIR)/elvis.pdb" /debug /machine:I386\
- /out:"$(OUTDIR)/elvis.exe"
+ /incremental:yes /pdb:"$(OUTDIR)/elvis.pdb" /debug /out:"$(OUTDIR)/elvis.exe"
 LINK32_OBJS= \
 	"$(INTDIR)/dmmarkup.obj" \
 	"$(INTDIR)/tcaphelp.obj" \

--- a/oswin32/elvis.mak
+++ b/oswin32/elvis.mak
@@ -126,11 +126,11 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /FR /YX /c
-# ADD CPP /nologo /GX /O2 /I "oswin32" /I "." /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /YX /c
+# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /FR /c
+# ADD CPP /nologo /GX /O2 /I "oswin32" /I "." /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /c
 # SUBTRACT CPP /Fr
 CPP_PROJ=/nologo /ML /GX /O2 /I "oswin32" /I "." /D "WIN32" /D "NDEBUG" /D\
- "_CONSOLE" /Fp"$(INTDIR)/elvis.pch" /YX /Fo"$(INTDIR)/" /c 
+ "_CONSOLE" /Fo"$(INTDIR)/" /c 
 CPP_OBJS=.\WinRel/
 CPP_SBRS=
 # ADD BASE RSC /l 0x409 /d "NDEBUG"
@@ -317,12 +317,11 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-# ADD BASE CPP /nologo /W3 /GX /Zi /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /FR /YX /c
-# ADD CPP /nologo /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /YX /c
+# ADD BASE CPP /nologo /W3 /GX /Zi /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /FR /c
+# ADD CPP /nologo /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /c
 # SUBTRACT CPP /Fr
 CPP_PROJ=/nologo /MLd /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." /D "WIN32" /D\
- "_DEBUG" /D "_CONSOLE" /Fp"$(INTDIR)/elvis.pch" /YX /Fo"$(INTDIR)/"\
- /Fd"$(INTDIR)/" /c 
+ "_DEBUG" /D "_CONSOLE" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 CPP_OBJS=.\WinDebug/
 CPP_SBRS=
 # ADD BASE RSC /l 0x409 /d "_DEBUG"

--- a/oswin32/elvisutl.mak
+++ b/oswin32/elvisutl.mak
@@ -17,8 +17,7 @@ CPP_PROJ=/nologo /ML /W3 /GX /O2 /I "oswin32" /I "." /D "WIN32" /D "NDEBUG"\
 CPP_OBJS=.\WinRel/
 
 LINK32=link.exe
-LINK32_FLAGS=kernel32.lib /NOLOGO /SUBSYSTEM:console /INCREMENTAL:no\
- /MACHINE:I386
+LINK32_FLAGS=kernel32.lib /NOLOGO /SUBSYSTEM:console /INCREMENTAL:no
 DEF_FILE=oswin32\osdir.c
 
 ###############################################################################

--- a/oswin32/elvisutl.mak
+++ b/oswin32/elvisutl.mak
@@ -12,7 +12,7 @@ $(INTDIR) :
 $(OUTDIR) : 
 	if not exist $(OUTDIR)\nul mkdir $(OUTDIR)
 
-CPP_PROJ=/nologo /ML /W3 /GX /YX /O2 /I "oswin32" /I "." /D "WIN32" /D "NDEBUG"\
+CPP_PROJ=/nologo /ML /W3 /GX /O2 /I "oswin32" /I "." /D "WIN32" /D "NDEBUG"\
  /D "_CONSOLE" /FR$(INTDIR)/ /Fo$(INTDIR)/ /c 
 CPP_OBJS=.\WinRel/
 

--- a/oswin32/winelvis.mak
+++ b/oswin32/winelvis.mak
@@ -10,15 +10,14 @@ INTDIR=GuiRel
 CFLAGS=/nologo /ML /W1 /GX /O2 /I "." /I ".." /I "oswin32" /I "..\oswin32" \
  /D "NDEBUG" /D "WIN32" /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /c 
 RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res" /d "NDEBUG" 
-LDFLAGS=/nologo /subsystem:windows /incremental:no /machine:I386 \
- /out:"WinElvis.exe" 
+LDFLAGS=/nologo /subsystem:windows /incremental:no /out:"WinElvis.exe" 
 !ELSE
 INTDIR=GuiDebug
 CFLAGS=/nologo /MLd /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." /D "WIN32" \
  /D "_DEBUG" /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res"
 LDFLAGS=/nologo /subsystem:windows /incremental:no /pdb:"elvis.pdb" \
- /debug /machine:I386 /out:"WinElvis.exe" 
+ /debug /out:"WinElvis.exe" 
 !ENDIF
 CPP_OBJS=$(INTDIR)/
 HDRS=autocmd.h buffer.h buffer2.h calc.h color.h config.h cut.h descr.h \

--- a/oswin32/winelvis.mak
+++ b/oswin32/winelvis.mak
@@ -15,8 +15,7 @@ LDFLAGS=/nologo /subsystem:windows /incremental:no /machine:I386 \
 !ELSE
 INTDIR=GuiDebug
 CFLAGS=/nologo /MLd /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." /D "WIN32" \
- /D "_DEBUG" /D "_WINDOWS" /D "GUI_WIN32" /Fp"$(INTDIR)/elvis.pch" /YX \
- /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
+ /D "_DEBUG" /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res"
 LDFLAGS=/nologo /subsystem:windows /incremental:no /pdb:"elvis.pdb" \
  /debug /machine:I386 /out:"WinElvis.exe" 

--- a/oswin32/winelvis.mak
+++ b/oswin32/winelvis.mak
@@ -28,8 +28,8 @@ HDRS=autocmd.h buffer.h buffer2.h calc.h color.h config.h cut.h descr.h \
  oswin32\osdef.h regexp.h region.h safe.h scan.h session.h spell.h state.h \
  state2.h tag.h version.h vi.h vicmd.h window.h
 GUIHDRS=guiwin32\winelvis.h guiwin32\wintools.h
-LIBS=kernel32.lib user32.lib gdi32.lib winspool.lib comctl32.lib comdlg32.lib \
- advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib wsock32.lib
+LIBS=kernel32.lib user32.lib gdi32.lib comctl32.lib comdlg32.lib shell32.lib \
+ wsock32.lib
 LINK32_OBJS= \
 	"$(INTDIR)/guiwin.obj" \
 	"$(INTDIR)/gwcmd.obj" \

--- a/oswin32/wintags.mak
+++ b/oswin32/wintags.mak
@@ -2,6 +2,7 @@
 CC=cl.exe
 RC=rc.exe
 LD=link.exe
+INTDIR=.\GuiRel
 INCL=/I "." /I ".." /I "oswin32" /I "..\oswin32" /I "guiwin32"
 CFLAGS=/nologo /ML /W3 /GX /O2 /D "NDEBUG" /D "WIN32" /D "_WINDOWS" \
 	/D "GUI_WIN32" /Fo"$(INTDIR)/" $(INCL)
@@ -9,7 +10,6 @@ LDFLAGS=kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib\
 	advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib /nologo\
 	/subsystem:windows /incremental:no
 RCFLAGS=/l 0x409 /fo"$(INTDIR)/wintags.res" /d "NDEBUG" 
-INTDIR=.\GuiRel
 OBJS=$(INTDIR)\wintags.obj $(INTDIR)\wintools.obj $(INTDIR)\ctags.obj \
 	$(INTDIR)\tag.obj $(INTDIR)\safe.obj $(INTDIR)\wintags.res
 HDRS=elvis.h guiwin32\wintools.h config.h elvctype.h version.h oswin32\osdef.h \

--- a/oswin32/wintags.mak
+++ b/oswin32/wintags.mak
@@ -7,7 +7,7 @@ CFLAGS=/nologo /ML /W3 /GX /O2 /D "NDEBUG" /D "WIN32" /D "_WINDOWS" \
 	/D "GUI_WIN32" /Fo"$(INTDIR)/" $(INCL)
 LDFLAGS=kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib\
 	advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib /nologo\
-	/subsystem:windows /incremental:no /machine:I386
+	/subsystem:windows /incremental:no
 RCFLAGS=/l 0x409 /fo"$(INTDIR)/wintags.res" /d "NDEBUG" 
 INTDIR=.\GuiRel
 OBJS=$(INTDIR)\wintags.obj $(INTDIR)\wintools.obj $(INTDIR)\ctags.obj \


### PR DESCRIPTION
These are less significant than the last round.  Four things:

1. /YX means "automatic precompiled header", where the first compiler instance compiles headers and stores them in a .pch file, and later compiler instances consume from that file.  This scheme assumes serial compilation (only one compiler instance is active at a time), and has been removed from newer compilers which generate a warning instead.  This change removes /YX and the /Fp directive that named the precompiled header.
2. Remove more import libraries from WinElvis.exe.  This is really something I missed somehow in my last round of changes, so it's finishing what I started from last time.
3. Remove /machine:i386 from linking.  The original IDEs inserted this into Makefiles so that you could have a different project with different settings for i386, MIPS, PowerPC and Alpha.  The linker will default to a native architecture for the platform it supports, meaning that Visual Studio ships with a linker that generates i386 code, and a linker that generates x64 code.  This change just removes the explicit indication and lets the toolchain target the architecture that it supports.  Note that this is a linker flag, so the objects have already been compiled, and the linker expects objects in the same architecture that it's linking against, so this flag is insufficient to do anything like cross-compilation.  After this change, it's possible to compile as 64 bit, which compiles successfully and runs but there's more scrubbing required to eliminate truncation conditions and ensure it's really correct.
4. One of the makefiles used a variable before defining it, which is actually legal in NMAKE since it originally only performed delayed variable expansion.  It doesn't seem compatible with much else though, and there doesn't seem to be a good reason to keep it.