### PR TITLE
Modern toolchain warnings

### DIFF
--- a/oswin32/elvis.mak
+++ b/oswin32/elvis.mak
@@ -34,6 +34,8 @@ NULL=nul
 CPP=cl.exe
 RSC=rc.exe
 
+C_DEFINES=/D _CRT_SECURE_NO_WARNINGS=1 /D _CRT_NONSTDC_NO_WARNINGS=1 /D WIN32
+
 !IF  "$(CFG)" == "elvis - Win32 Release"
 
 # PROP BASE Use_MFC 0
@@ -126,10 +128,7 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /FR /c
-# ADD CPP /nologo /GX /O2 /I "oswin32" /I "." /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /c
-# SUBTRACT CPP /Fr
-CPP_PROJ=/nologo /ML /GX /O2 /I "oswin32" /I "." /D "WIN32" /D "NDEBUG" /D\
+CPP_PROJ=/nologo /ML /GX /O2 /I "oswin32" /I "." $(C_DEFINES) /D "NDEBUG" /D\
  "_CONSOLE" /Fo"$(INTDIR)/" /c 
 CPP_OBJS=.\WinRel/
 CPP_SBRS=
@@ -316,10 +315,7 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-# ADD BASE CPP /nologo /W3 /GX /Zi /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /FR /c
-# ADD CPP /nologo /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /c
-# SUBTRACT CPP /Fr
-CPP_PROJ=/nologo /MLd /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." /D "WIN32" /D\
+CPP_PROJ=/nologo /MLd /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." $(C_DEFINES) /D\
  "_DEBUG" /D "_CONSOLE" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 CPP_OBJS=.\WinDebug/
 CPP_SBRS=

--- a/oswin32/elvis.mak
+++ b/oswin32/elvis.mak
@@ -28,6 +28,22 @@ NULL=
 !ELSE 
 NULL=nul
 !ENDIF 
+
+# Check if the compiler supports single threaded statically linked CRT (-ML),
+# and if so, use it. Newer compilers don't, so fall back to -MT (statically
+# linked multithreaded.)
+!IF [$(CC) -ML 2>&1 | find "D9002" >NUL]==0
+CRTFLAG_RELEASE=/MT
+CRTFLAG_DEBUG=/MTd
+!ELSE
+CRTFLAG_RELEASE=/ML
+!IF [$(CC) -MLd 2>&1 | find "D4002" >NUL]==0
+CRTFLAG_DEBUG=/ML
+!ELSE
+CRTFLAG_DEBUG=/MLd
+!ENDIF
+!ENDIF
+
 ################################################################################
 # Begin Project
 # PROP Target_Last_Scanned "elvis - Win32 Debug"
@@ -128,8 +144,8 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP_PROJ=/nologo /ML /O2 /I "oswin32" /I "." $(C_DEFINES) /D "NDEBUG" /D\
- "_CONSOLE" /Fo"$(INTDIR)/" /c 
+CPP_PROJ=/nologo $(CRTFLAG_RELEASE) /O2 /I "oswin32" /I "." $(C_DEFINES) \
+ /D "NDEBUG" /D "_CONSOLE" /Fo"$(INTDIR)/" /c 
 CPP_OBJS=.\WinRel/
 CPP_SBRS=
 # ADD BASE RSC /l 0x409 /d "NDEBUG"
@@ -315,8 +331,8 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP_PROJ=/nologo /MLd /W3 /Z7 /Od /I "oswin32" /I "." $(C_DEFINES) /D\
- "_DEBUG" /D "_CONSOLE" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
+CPP_PROJ=/nologo $(CRTFLAG_DEBUG) /W3 /Z7 /Od /I "oswin32" /I "." $(C_DEFINES)\
+ /D "_DEBUG" /D "_CONSOLE" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 CPP_OBJS=.\WinDebug/
 CPP_SBRS=
 # ADD BASE RSC /l 0x409 /d "_DEBUG"

--- a/oswin32/elvis.mak
+++ b/oswin32/elvis.mak
@@ -128,7 +128,7 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP_PROJ=/nologo /ML /GX /O2 /I "oswin32" /I "." $(C_DEFINES) /D "NDEBUG" /D\
+CPP_PROJ=/nologo /ML /O2 /I "oswin32" /I "." $(C_DEFINES) /D "NDEBUG" /D\
  "_CONSOLE" /Fo"$(INTDIR)/" /c 
 CPP_OBJS=.\WinRel/
 CPP_SBRS=
@@ -315,7 +315,7 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP_PROJ=/nologo /MLd /W3 /GX /Z7 /Od /I "oswin32" /I "." $(C_DEFINES) /D\
+CPP_PROJ=/nologo /MLd /W3 /Z7 /Od /I "oswin32" /I "." $(C_DEFINES) /D\
  "_DEBUG" /D "_CONSOLE" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 CPP_OBJS=.\WinDebug/
 CPP_SBRS=

--- a/oswin32/elvis.mak
+++ b/oswin32/elvis.mak
@@ -315,7 +315,7 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP_PROJ=/nologo /MLd /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." $(C_DEFINES) /D\
+CPP_PROJ=/nologo /MLd /W3 /GX /Z7 /Od /I "oswin32" /I "." $(C_DEFINES) /D\
  "_DEBUG" /D "_CONSOLE" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 CPP_OBJS=.\WinDebug/
 CPP_SBRS=

--- a/oswin32/elvis.mak
+++ b/oswin32/elvis.mak
@@ -330,7 +330,7 @@ LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib wsock32.lib user32.lib /nologo /subsystem:console /debug
 # ADD LINK32 wsock32.lib kernel32.lib user32.lib /nologo /subsystem:console /debug
 LINK32_FLAGS=wsock32.lib kernel32.lib user32.lib /nologo /subsystem:console\
- /incremental:yes /pdb:"$(OUTDIR)/elvis.pdb" /debug /out:"$(OUTDIR)/elvis.exe"
+ /incremental:no /pdb:"$(OUTDIR)/elvis.pdb" /debug /out:"$(OUTDIR)/elvis.exe"
 LINK32_OBJS= \
 	"$(INTDIR)/dmmarkup.obj" \
 	"$(INTDIR)/tcaphelp.obj" \

--- a/oswin32/elvisutl.mak
+++ b/oswin32/elvisutl.mak
@@ -3,6 +3,8 @@ RSC=rc.exe
 OUTDIR=.
 INTDIR=.\WinRel
 
+C_DEFINES=/D _CRT_SECURE_NO_WARNINGS=1 /D _CRT_NONSTDC_NO_WARNINGS=1 /D WIN32
+
 ALL : $(INTDIR) $(OUTDIR)\ctags.exe $(OUTDIR)\fmt.exe $(OUTDIR)\ref.exe\
  $(OUTDIR)\ls.exe $(OUTDIR)\vi.exe $(OUTDIR)\ex.exe $(OUTDIR)\view.exe
 
@@ -12,7 +14,7 @@ $(INTDIR) :
 $(OUTDIR) : 
 	if not exist $(OUTDIR)\nul mkdir $(OUTDIR)
 
-CPP_PROJ=/nologo /ML /W3 /GX /O2 /I "oswin32" /I "." /D "WIN32" /D "NDEBUG"\
+CPP_PROJ=/nologo /ML /W3 /GX /O2 /I "oswin32" /I "." $(C_DEFINES) /D "NDEBUG"\
  /D "_CONSOLE" /FR$(INTDIR)/ /Fo$(INTDIR)/ /c 
 CPP_OBJS=.\WinRel/
 

--- a/oswin32/elvisutl.mak
+++ b/oswin32/elvisutl.mak
@@ -14,7 +14,7 @@ $(INTDIR) :
 $(OUTDIR) : 
 	if not exist $(OUTDIR)\nul mkdir $(OUTDIR)
 
-CPP_PROJ=/nologo /ML /W3 /GX /O2 /I "oswin32" /I "." $(C_DEFINES) /D "NDEBUG"\
+CPP_PROJ=/nologo /ML /W3 /O2 /I "oswin32" /I "." $(C_DEFINES) /D "NDEBUG"\
  /D "_CONSOLE" /FR$(INTDIR)/ /Fo$(INTDIR)/ /c 
 CPP_OBJS=.\WinRel/
 

--- a/oswin32/elvisutl.mak
+++ b/oswin32/elvisutl.mak
@@ -1,4 +1,12 @@
-CPP=cl.exe
+# Check if the compiler supports single threaded statically linked CRT (-ML),
+# and if so, use it. Newer compilers don't, so fall back to -MT (statically
+# linked multithreaded.)
+!IF [$(CC) -ML 2>&1 | find "D9002" >NUL]==0
+CRTFLAG_RELEASE=/MT
+!ELSE
+CRTFLAG_RELEASE=/ML
+!ENDIF
+
 RSC=rc.exe
 OUTDIR=.
 INTDIR=.\WinRel
@@ -14,8 +22,8 @@ $(INTDIR) :
 $(OUTDIR) : 
 	if not exist $(OUTDIR)\nul mkdir $(OUTDIR)
 
-CPP_PROJ=/nologo /ML /W3 /O2 /I "oswin32" /I "." $(C_DEFINES) /D "NDEBUG"\
- /D "_CONSOLE" /FR$(INTDIR)/ /Fo$(INTDIR)/ /c 
+CPP_PROJ=/nologo $(CRTFLAG_RELEASE) /W3 /O2 /I "oswin32" /I "." $(C_DEFINES) \
+ /D "NDEBUG" /D "_CONSOLE" /FR$(INTDIR)/ /Fo$(INTDIR)/ /c 
 CPP_OBJS=.\WinRel/
 
 LINK32=link.exe
@@ -63,22 +71,22 @@ $(OUTDIR)/ls.exe : $(OUTDIR) $(DEF_FILE) \
 <<
 
 $(OUTDIR)\vi.exe : $(OUTDIR)
-	cl /nologo /DARGV0=VI /Fe$(OUTDIR)\vi.exe /Fo$(INTDIR)\vi.obj /Ioswin32 alias.c
+	$(CC) /nologo /DARGV0=VI /Fe$(OUTDIR)\vi.exe /Fo$(INTDIR)\vi.obj /Ioswin32 alias.c
 
 $(OUTDIR)\ex.exe : $(OUTDIR)
-	cl /nologo /DARGV0=EX /Fe$(OUTDIR)\ex.exe /Fo$(INTDIR)\ex.obj /Ioswin32 alias.c
+	$(CC) /nologo /DARGV0=EX /Fe$(OUTDIR)\ex.exe /Fo$(INTDIR)\ex.obj /Ioswin32 alias.c
 
 $(OUTDIR)\view.exe : $(OUTDIR)
-	cl /nologo /DARGV0=VIEW /Fe$(OUTDIR)\view.exe /Fo$(INTDIR)\view.obj /Ioswin32 alias.c
+	$(CC) /nologo /DARGV0=VIEW /Fe$(OUTDIR)\view.exe /Fo$(INTDIR)\view.obj /Ioswin32 alias.c
 
 
 ###############################################################################
 
 .c{$(CPP_OBJS)}.obj:
-   $(CPP) $(CPP_PROJ) $<  
+   $(CC) $(CPP_PROJ) $<  
 
 {oswin32/}.c{$(CPP_OBJS)}.obj:
-   $(CPP) $(CPP_PROJ) $<  
+   $(CC) $(CPP_PROJ) $<  
 
 ################################################################################
 

--- a/oswin32/winelvis.mak
+++ b/oswin32/winelvis.mak
@@ -14,7 +14,7 @@ RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res" /d "NDEBUG"
 LDFLAGS=/nologo /subsystem:windows /incremental:no /out:"WinElvis.exe" 
 !ELSE
 INTDIR=GuiDebug
-CFLAGS=/nologo /MLd /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." $(C_DEFINES) \
+CFLAGS=/nologo /MLd /W3 /GX /Z7 /Od /I "oswin32" /I "." $(C_DEFINES) \
  /D "_DEBUG" /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res"
 LDFLAGS=/nologo /subsystem:windows /incremental:no /pdb:"elvis.pdb" \

--- a/oswin32/winelvis.mak
+++ b/oswin32/winelvis.mak
@@ -1,5 +1,21 @@
 # This is a hand-made Makefile.  MSVC++ can't read it, but NMAKE can.
 ###############################################################################
+
+# Check if the compiler supports single threaded statically linked CRT (-ML),
+# and if so, use it. Newer compilers don't, so fall back to -MT (statically
+# linked multithreaded.)
+!IF [$(CC) -ML 2>&1 | find "D9002" >NUL]==0
+CRTFLAG_RELEASE=/MT
+CRTFLAG_DEBUG=/MTd
+!ELSE
+CRTFLAG_RELEASE=/ML
+!IF [$(CC) -MLd 2>&1 | find "D4002" >NUL]==0
+CRTFLAG_DEBUG=/ML
+!ELSE
+CRTFLAG_DEBUG=/MLd
+!ENDIF
+!ENDIF
+
 # Macro definitions
 
 RSC=rc.exe
@@ -8,13 +24,14 @@ LD=link.exe
 C_DEFINES=/D _CRT_SECURE_NO_WARNINGS=1 /D _CRT_NONSTDC_NO_WARNINGS=1 /D WIN32
 !IF "$(CFG)" == "WinElvis - Win32 Release"
 INTDIR=GuiRel
-CFLAGS=/nologo /ML /W1 /O2 /I "." /I ".." /I "oswin32" /I "..\oswin32" \
- /D "NDEBUG" $(C_DEFINES) /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /c 
+CFLAGS=/nologo $(CRTFLAG_RELEASE) /W1 /O2 /I "." /I ".." /I "oswin32" \
+ /I "..\oswin32" /D "NDEBUG" $(C_DEFINES) /D "_WINDOWS" /D "GUI_WIN32" \
+ /Fo"$(INTDIR)/" /c 
 RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res" /d "NDEBUG" 
 LDFLAGS=/nologo /subsystem:windows /incremental:no /out:"WinElvis.exe" 
 !ELSE
 INTDIR=GuiDebug
-CFLAGS=/nologo /MLd /W3 /Z7 /Od /I "oswin32" /I "." $(C_DEFINES) \
+CFLAGS=/nologo $(CRTFLAG_DEBUG) /W3 /Z7 /Od /I "oswin32" /I "." $(C_DEFINES) \
  /D "_DEBUG" /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res"
 LDFLAGS=/nologo /subsystem:windows /incremental:no /pdb:"elvis.pdb" \

--- a/oswin32/winelvis.mak
+++ b/oswin32/winelvis.mak
@@ -8,13 +8,13 @@ LD=link.exe
 C_DEFINES=/D _CRT_SECURE_NO_WARNINGS=1 /D _CRT_NONSTDC_NO_WARNINGS=1 /D WIN32
 !IF "$(CFG)" == "WinElvis - Win32 Release"
 INTDIR=GuiRel
-CFLAGS=/nologo /ML /W1 /GX /O2 /I "." /I ".." /I "oswin32" /I "..\oswin32" \
+CFLAGS=/nologo /ML /W1 /O2 /I "." /I ".." /I "oswin32" /I "..\oswin32" \
  /D "NDEBUG" $(C_DEFINES) /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /c 
 RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res" /d "NDEBUG" 
 LDFLAGS=/nologo /subsystem:windows /incremental:no /out:"WinElvis.exe" 
 !ELSE
 INTDIR=GuiDebug
-CFLAGS=/nologo /MLd /W3 /GX /Z7 /Od /I "oswin32" /I "." $(C_DEFINES) \
+CFLAGS=/nologo /MLd /W3 /Z7 /Od /I "oswin32" /I "." $(C_DEFINES) \
  /D "_DEBUG" /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res"
 LDFLAGS=/nologo /subsystem:windows /incremental:no /pdb:"elvis.pdb" \

--- a/oswin32/winelvis.mak
+++ b/oswin32/winelvis.mak
@@ -5,15 +5,16 @@
 RSC=rc.exe
 CPP=cl.exe
 LD=link.exe
+C_DEFINES=/D _CRT_SECURE_NO_WARNINGS=1 /D _CRT_NONSTDC_NO_WARNINGS=1 /D WIN32
 !IF "$(CFG)" == "WinElvis - Win32 Release"
 INTDIR=GuiRel
 CFLAGS=/nologo /ML /W1 /GX /O2 /I "." /I ".." /I "oswin32" /I "..\oswin32" \
- /D "NDEBUG" /D "WIN32" /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /c 
+ /D "NDEBUG" $(C_DEFINES) /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /c 
 RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res" /d "NDEBUG" 
 LDFLAGS=/nologo /subsystem:windows /incremental:no /out:"WinElvis.exe" 
 !ELSE
 INTDIR=GuiDebug
-CFLAGS=/nologo /MLd /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." /D "WIN32" \
+CFLAGS=/nologo /MLd /W3 /Gm /GX /Zi /Od /I "oswin32" /I "." $(C_DEFINES) \
  /D "_DEBUG" /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" /Fd"$(INTDIR)/" /c 
 RSC_PROJ=/l 0x409 /fo"..\$(INTDIR)\winelvis.res"
 LDFLAGS=/nologo /subsystem:windows /incremental:no /pdb:"elvis.pdb" \

--- a/oswin32/wintags.mak
+++ b/oswin32/wintags.mak
@@ -4,7 +4,8 @@ RC=rc.exe
 LD=link.exe
 INTDIR=.\GuiRel
 INCL=/I "." /I ".." /I "oswin32" /I "..\oswin32" /I "guiwin32"
-CFLAGS=/nologo /ML /W3 /GX /O2 /D "NDEBUG" /D "WIN32" /D "_WINDOWS" \
+C_DEFINES=/D _CRT_SECURE_NO_WARNINGS=1 /D _CRT_NONSTDC_NO_WARNINGS=1 /D WIN32
+CFLAGS=/nologo /ML /W3 /GX /O2 /D "NDEBUG" $(C_DEFINES) /D "_WINDOWS" \
 	/D "GUI_WIN32" /Fo"$(INTDIR)/" $(INCL)
 LDFLAGS=kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib\
 	advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib /nologo\

--- a/oswin32/wintags.mak
+++ b/oswin32/wintags.mak
@@ -16,9 +16,7 @@ INCL=/I "." /I ".." /I "oswin32" /I "..\oswin32" /I "guiwin32"
 C_DEFINES=/D _CRT_SECURE_NO_WARNINGS=1 /D _CRT_NONSTDC_NO_WARNINGS=1 /D WIN32
 CFLAGS=/nologo $(CRTFLAG_RELEASE) /W3 /O2 /D "NDEBUG" $(C_DEFINES) \
     /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" $(INCL)
-LDFLAGS=kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib\
-	advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib /nologo\
-	/subsystem:windows /incremental:no
+LDFLAGS=kernel32.lib user32.lib /nologo /subsystem:windows /incremental:no
 RCFLAGS=/l 0x409 /fo"$(INTDIR)/wintags.res" /d "NDEBUG" 
 OBJS=$(INTDIR)\wintags.obj $(INTDIR)\wintools.obj $(INTDIR)\ctags.obj \
 	$(INTDIR)\tag.obj $(INTDIR)\safe.obj $(INTDIR)\wintags.res

--- a/oswin32/wintags.mak
+++ b/oswin32/wintags.mak
@@ -1,12 +1,21 @@
 # hand-made NMAKE File.
-CC=cl.exe
+
+# Check if the compiler supports single threaded statically linked CRT (-ML),
+# and if so, use it. Newer compilers don't, so fall back to -MT (statically
+# linked multithreaded.)
+!IF [$(CC) -ML 2>&1 | find "D9002" >NUL]==0
+CRTFLAG_RELEASE=/MT
+!ELSE
+CRTFLAG_RELEASE=/ML
+!ENDIF
+
 RC=rc.exe
 LD=link.exe
 INTDIR=.\GuiRel
 INCL=/I "." /I ".." /I "oswin32" /I "..\oswin32" /I "guiwin32"
 C_DEFINES=/D _CRT_SECURE_NO_WARNINGS=1 /D _CRT_NONSTDC_NO_WARNINGS=1 /D WIN32
-CFLAGS=/nologo /ML /W3 /O2 /D "NDEBUG" $(C_DEFINES) /D "_WINDOWS" \
-	/D "GUI_WIN32" /Fo"$(INTDIR)/" $(INCL)
+CFLAGS=/nologo $(CRTFLAG_RELEASE) /W3 /O2 /D "NDEBUG" $(C_DEFINES) \
+    /D "_WINDOWS" /D "GUI_WIN32" /Fo"$(INTDIR)/" $(INCL)
 LDFLAGS=kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib\
 	advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib /nologo\
 	/subsystem:windows /incremental:no

--- a/oswin32/wintags.mak
+++ b/oswin32/wintags.mak
@@ -5,7 +5,7 @@ LD=link.exe
 INTDIR=.\GuiRel
 INCL=/I "." /I ".." /I "oswin32" /I "..\oswin32" /I "guiwin32"
 C_DEFINES=/D _CRT_SECURE_NO_WARNINGS=1 /D _CRT_NONSTDC_NO_WARNINGS=1 /D WIN32
-CFLAGS=/nologo /ML /W3 /GX /O2 /D "NDEBUG" $(C_DEFINES) /D "_WINDOWS" \
+CFLAGS=/nologo /ML /W3 /O2 /D "NDEBUG" $(C_DEFINES) /D "_WINDOWS" \
 	/D "GUI_WIN32" /Fo"$(INTDIR)/" $(INCL)
 LDFLAGS=kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib\
 	advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib /nologo\


### PR DESCRIPTION
The previous code compiles with modern versions of Visual C++ but emits a lot of warnings related to the use of toolchain facilities that have been removed, deprecated or discouraged.  These aren't related to code and wouldn't occur on other platforms.  This change addresses these to make the build a lot quieter and leave warnings related to code issues.

1. As part of Microsoft's 2004 security push, compilers warn about the use of non-bounds-checked CRT functions such as strcpy.  These aren't necessarily code bugs and portability often requires them to be used.  This change disables these warnings.  Note this is done via Makefiles because the #define needs to be made before including any CRT headers, and there are quite a few places where these would need to be in code to achieve the same result.  Keeping them in Makefiles also limits them in scope to Win32.
2. Debug information can be emitted in one of two ways: `/Zi` places this in a single .pdb file, and `/Z7` places debug information into each object file.  Using a shared pdb file can interfere with parallel builds, because only one compiler instance can update the file at a time.  Note the linker will emit a single .pdb file regardless of what happens here - this just decides where the compiler puts information before linking starts.
3. `/incremental:yes` was used for linking the debug version of elvis.exe, and doesn't appear anywhere else.  This functionality is no longer supported by the linker and it emits a warning for it.  There's also a `/Gm` "minimal rebuild" compiler switch which is no longer supported.
4. The previous makefiles specify `/GX` which is to enable C++ exception handling.  Current compiler versions want this specified by `/EHsc`.  However, I don't think C++ exception handling is needed or desired, since this is C code and I can't find evidence of it using exceptions.  I think this is just a default value generated by the IDE which has been carried forward, and having the compiler emit instructions that are robust to exceptions makes the code less efficient (since it has to ensure local variables are pushed to the stack across function calls so unwind code can find them.)
5. The original Win32 compilers expose three forms of the C runtime library: a single threaded statically linked version (`/ML`), a multi threaded statically linked version (`/MT`) and a multi threaded dynamically linked version (`/MD`).  As multi threading has become more standard, the single threaded variant was later dropped.  This code dynamically checks whether the compiler supports `/ML`, uses it if so, and if not uses `/MT` to preserve the static linking behavior.  Note that dynamic linking results in smaller code but requires the user to install the Visual C++ runtime redistributable matching the compiler that generated the code.  Also, Visual C++ 4 added debug versions of the CRT, specified with `/MLd` etc.  I've personally never found these useful but this change retains the previous behavior of using these for debug builds, except on Visual C++ 2 which doesn't include them.
6. More removing of unused import libraries (sigh.)