### PR TITLE
Remove memory size and free disk space from about dialog

### DIFF
--- a/guiwin32/WinElvis.rc
+++ b/guiwin32/WinElvis.rc
@@ -158,22 +158,17 @@ BEGIN
                     WS_VISIBLE | WS_GROUP | WS_TABSTOP,103,68,50,12
 END
 
-IDD_ABOUT DIALOG DISCARDABLE  0, 0, 199, 109
+IDD_ABOUT DIALOG DISCARDABLE  0, 0, 199, 68
 STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "About WinElvis"
 FONT 8, "MS Sans Serif"
 BEGIN
-    DEFPUSHBUTTON   "OK",IDOK,74,88,50,14
+    DEFPUSHBUTTON   "OK",IDOK,74,48,50,14
     ICON            IDI_ELVIS,IDC_STATIC,7,7,18,20
     CTEXT           "WinElvis Version ",IDAB_VERSION,41,7,151,8
     CTEXT           "Copyright 2003, Steve Kirkendall",IDC_STATIC,41,19,151,
                     8
     CTEXT           "Windows Port by Serge Pirotte",IDC_STATIC,41,31,151,8
-    LTEXT           "Physical Memory :",IDC_STATIC,41,56,62,8
-    LTEXT           "Disk Space :",IDC_STATIC,41,68,59,8
-    LTEXT           "",IDAB_PHYS_MEM,103,56,89,8
-    LTEXT           "",IDAB_DISK_SPACE,103,68,89,8
-    CONTROL         "",IDC_STATIC,"Static",SS_BLACKRECT,41,48,151,1
 END
 
 IDD_GOTO DIALOG DISCARDABLE  0, 0, 118, 68

--- a/guiwin32/elvisres.h
+++ b/guiwin32/elvisres.h
@@ -24,8 +24,6 @@
 #define IDD_OPT_GLOBAL                  121
 #define IDD_OPT_GUI                     122
 #define IDI_ICON2                       126
-#define IDAB_PHYS_MEM                   1000
-#define IDAB_DISK_SPACE                 1001
 #define IDBL_BUFFERS                    1002
 #define IDGT_LINE                       1003
 #define IDSR_IGNORECASE                 1004

--- a/guiwin32/gwdlgs.c
+++ b/guiwin32/gwdlgs.c
@@ -1256,13 +1256,6 @@ BOOL CALLBACK DlgOptUser (HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 BOOL CALLBACK DlgAbout (HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 {
-	MEMORYSTATUS        memstat;
-	int                 drive;
-	int                 disk_size;
-	DWORD               spc;
-	DWORD               bps;
-	DWORD               nfc;
-	DWORD               tfc;
 	char                str[80];
 
 	switch (msg) {
@@ -1271,17 +1264,6 @@ BOOL CALLBACK DlgAbout (HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 			sprintf(str, "WinElvis Version %s", VERSION);
 			SetDlgItemText (hwnd, IDAB_VERSION, str);
-
-			memstat.dwLength = sizeof(MEMORYSTATUS);
-			GlobalMemoryStatus (&memstat);
-			sprintf (str, "%d Kbytes", memstat.dwTotalPhys / 1024L);
-			SetDlgItemText (hwnd, IDAB_PHYS_MEM, str);
-
-			drive = _getdrive ();
-			GetDiskFreeSpace (NULL, &spc, &bps, &nfc, &tfc);
-			disk_size = (spc * bps * nfc) / 1024L;
-			sprintf (str, "%d Kbytes free on %c:", disk_size, drive - 1 + 'A');
-			SetDlgItemText (hwnd, IDAB_DISK_SPACE, str);
 
 			return TRUE;
 


### PR DESCRIPTION
The 64 bit changes showed potential integer overflows when reporting memory capacity.  A closer look at this code though shows it's using GetDiskFreeSpace which can't report disk capacities above 2Gb, so the disk space report has been wrong for a long time.  I think that including memory size and disk free space in the about dialog isn't that helpful and isn't where users would look for it today, so this PR removes those values.

Alternatively, I could make changes to make these values correct if they're worth preserving.  This means querying memory and disk space using newer APIs and falling back to older APIs as needed.  It probably also means reporting capacities in Mb or Gb as appropriate.  Let me know if you'd prefer that change instead.