### PR TITLE
configure script: updated the freebsd and openbsd case statements to make it work for building without X11

### DIFF
--- a/configure
+++ b/configure
@@ -742,16 +742,22 @@ case "$SYS" in
   *freebsd*)
 	why "For FreeBSD, we ignore the <sys/select.h> file"
 	NEED_SELECT_H="undef"
-	who "   To support X11, it also requires -lipc"
-	XLIBS=" -lipc"
+	if [ "$GUI_X11" = "define" ]
+	then
+		why "   To support X11, it also requires -lipc"
+		XLIBS=" -lipc"
+	fi
 	;;
 
   *openbsd*)
 	why "For OpenBSD, we ignore the <sys/select.h> file"
 	NEED_SELECT_H="undef"
 	TLIBS="-lcurses"
-	who "   To support X11, it also requires -lipc"
-	XLIBS=" -lipc"
+	if [ "$GUI_X11" = "define" ]
+	then
+		why "   To support X11, it also requires -lipc"
+		XLIBS=" -lipc"
+	fi
 	;;
 
   *netbsd*)


### PR DESCRIPTION
Currently, I have encountered some issues when building on freebsd and openbsd without X11.

Despite specifying `with-x=no` or `without-x` when running the configure script, the build process still tries to link the ipc dynamic library and it will exit with the following error messages: 
`ld: error: unable to find library -lipc`
`cc: error: linker command failed with exit code 1 (use -v to see invocation)`

After adding the `"$GUI_X11" = "define"` condition to the freebsd and openbsd case statements, the build process is able to run sucessfully.

I have also changed the 2 occurances of `who` to `why` for these 2 case statements, as only `why` is defined as a function.